### PR TITLE
Handle workflowGuid index with many documents

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -372,7 +372,7 @@ module.exports = function(self, options) {
               }
             }
           }
-        ]).toArray();
+        ], { allowDiskUse: true }).toArray();
       })
       .then(function(groups) {
         return Promise.mapSeries(groups, function(group) {


### PR DESCRIPTION
When there are too many documents in database, the aggregate to find duplicate documents fails. The option `allowDiskUse: true` handles this case.