### PR TITLE
even draft locales must run through the parking code. Yes they get au…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -696,7 +696,7 @@ module.exports = function(self, options) {
             _live.trash = false;
           }
           if (!_.isEqual(_draft, _live)) {
-            // console.log('***', JSON.stringify(_draft, null, '  '), JSON.stringify(_live, null, '  '));
+//            console.log('***', JSON.stringify(_draft, null, '  '), JSON.stringify(_live, null, '  '));
             relatedModified.push(draft);
           } else {
             relatedUnmodified.push(draft);

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -271,12 +271,8 @@ module.exports = {
 
       function park(callback) {
         var workflow = self.apos.modules['apostrophe-workflow'];
-        return async.eachSeries(_.keys(workflow.locales), function(locale, callback) {
-          if (locale.match(/-draft/)) {
-            // Skip the draft locales, the doc will automatically get created
-            // in both draft and live locales
-            return setImmediate(callback);
-          }
+        var locales = _.keys(workflow.locales);
+        return async.eachSeries(locales, function(locale, callback) {
           var parked = _.cloneDeep(self.parked);
           if (workflow.prefixes) {
             fixPrefixes(parked, locale);
@@ -290,7 +286,7 @@ module.exports = {
           }, callback);
 
           function fixPrefixes(parked, locale) {
-            var prefix = workflow.prefixes[locale];
+            var prefix = workflow.prefixes[workflow.liveify(locale)];
             if (!prefix) {
               return;
             }


### PR DESCRIPTION
…toinserted if the live does not exist yet, however that does not account for updates to parked properties of existing docs, which may or may not be needed regardless of locale