### PR TITLE
fix(link-to-locale): handle doc not found and log it

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1010,12 +1010,13 @@ module.exports = function(self, options) {
         console.error(err);
         return res.status(500).send('error');
       }
-      if (doc._url) {
+      if (doc && doc._url) {
         // Last step is to use the workflowLocale query parameter to
         // disambiguate cases where locales have the same URL, which
         // seems pretty silly but can happen in dev
         return res.redirect(self.apos.urls.build(doc._url, { workflowLocale: locale }));
       } else {
+        console.error('link-to-locale: No doc found for slug "' + req.query.slug + '" and locale "' + req.query.locale + '"');
         return res.status(404).send('not found');
       }
     });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1007,7 +1007,7 @@ module.exports = function(self, options) {
     }
     return self.apos.docs.find(req, criteria).published(null).toObject(function(err, doc) {
       if (err) {
-        console.error(err);
+        self.apos.utils.error(err);
         return res.status(500).send('error');
       }
       if (doc && doc._url) {
@@ -1016,7 +1016,7 @@ module.exports = function(self, options) {
         // seems pretty silly but can happen in dev
         return res.redirect(self.apos.urls.build(doc._url, { workflowLocale: locale }));
       } else {
-        console.error('link-to-locale: No doc found for slug "' + req.query.slug + '" and locale "' + req.query.locale + '"');
+        self.apos.utils.error('link-to-locale: No doc found for slug "' + req.query.slug + '" and locale "' + req.query.locale + '"');
         return res.status(404).send('not found');
       }
     });


### PR DESCRIPTION
Hi,

we have a recurring issue on our prod environment:
```sh
/app/node_modules/apostrophe-workflow/lib/routes.js:1013
      if (doc._url) {
             ^
TypeError: Cannot read property '_url' of undefined
    at /app/node_modules/apostrophe-workflow/lib/routes.js:1013:14
```

We do not and cannot reproduce the issue, but after looking after the code, it seems it can be more robust, to handle the case where a doc is not found.
We added some error log, the case should not occurs and to have more information.

It would be nice to have it included in the next bug-fix release ;)