### PR TITLE
pass on all flags relating to the --live option properly

### DIFF
--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -26,7 +26,6 @@ module.exports = function(self, options) {
   // don't clutter reorganize as "unpublished."
 
   self.docAfterSave = function(req, doc, options, callback) {
-
     var missingLocales;
 
     if (doc._workflowPropagating) {
@@ -133,20 +132,20 @@ module.exports = function(self, options) {
           } else if (manager.insert) {
             // A piece, or something else with a direct insert method;
             // simple
-            return manager.insert(req, _doc, { permissions: false }, callback);
+            return manager.insert(req, _doc, { permissions: false, workflowMissingLocalesLive: options.workflowMissingLocalesLive }, callback);
           } else {
             // Something Else. Currently, nothing in this category, but
             // inserting via docs.insert is a good fallback
             return insertDoc(callback);
           }
           function beforeInsert(callback) {
-            return self.apos.pages.beforeInsert(req, _doc, { permissions: false }, callback);
+            return self.apos.pages.beforeInsert(req, _doc, { permissions: false, workflowMissingLocalesLive: options.workflowMissingLocalesLive }, callback);
           }
           function beforeSave(callback) {
-            return self.apos.pages.beforeSave(req, _doc, { permissions: false }, callback);
+            return self.apos.pages.beforeSave(req, _doc, { permissions: false, workflowMissingLocalesLive: options.workflowMissingLocalesLive }, callback);
           }
           function insertDoc(callback) {
-            return self.apos.docs.insert(req, _doc, { permissions: false }, callback);
+            return self.apos.docs.insert(req, _doc, { permissions: false, workflowMissingLocalesLive: options.workflowMissingLocalesLive }, callback);
           }
         }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -117,7 +117,7 @@ module.exports = function(self, options) {
           return setImmediate(callback);
         }
         doc.workflowResolveDeferred = true;
-        return self.docAfterSave(req, doc, { permissions: false }, function(err) {
+        return self.docAfterSave(req, doc, { permissions: false, workflowMissingLocalesLive: argv.live ? true : 'liveOnly' }, function(err) {
           return callback(err);
         });
       }, callback);


### PR DESCRIPTION
The `--live` option to `apostrophe-workflow:add-missing-locales` was not being passed on properly in all situations.