### PR TITLE
dgad-484: no more need to run add-missing-locales or add-locale-prefixes, Apostrophe just figures it out

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,20 @@ If you are using the `park` option with `apostrophe-pages`, and you have not alr
 
 Odds are, you already have a database. Either from an existing project, or for a new one, since Apostrophe creates the database on the very first run. So, follow these steps to add workflow to your database.
 
-1. **FOR EXISTING PROJECTS, BACK UP YOUR DATABASE,** In case you decide this module is not for you, or decide you should have used the `--live` option as seen below. Currently there is no command to stop using workflow once you start.
+1. **FOR EXISTING PROJECTS, BACK UP YOUR DATABASE,** In case you decide this module is not for you. Currently there is no command to stop using workflow once you start.
 
 You should initially experiment with this module with a *local* copy of your site, not your live production content.
 
 You can back up your database easily with the `mongodump` command line utility.
 
-2. Execute this task:
-
-```
-node app apostrophe-workflow:add-missing-locales --live
-```
-
-**You should not have to do this more than once,** except when adding new locales (see "localization" below).
-
-Once you run this task, all of your documents will exist in both draft and live versions. Editors will be able to the draft version while in "draft" mode. Everyone else, and editors in "live" mode, will see the live version and will not be able to edit it directly. The only way to make new content live is to "commit" the changes that have been made to the document.
+**Once you add this module and restart your apostrophe process,** all of your documents will exist in both draft and live versions. Editors will be able to the draft version while in "draft" mode. Everyone else, and editors in "live" mode, will see the live version and will not be able to edit it directly. The only way to make new content live is to "commit" the changes that have been made to the document.
 
 If you have not added an admin user yet, you can do it now in the usual way:
 
 ```
+# If you do not have preconfigured groups, add a group too
+node app apostrophe-groups:add admin admin
+# Now add the user
 node app apostrophe-users:add admin admin
 ```
 
@@ -120,13 +115,15 @@ If you have worked with localization before you will recognize locale names like
 >
 > The parent-child relationship between locales is just a convenience for quickly exporting content to them, as you'll see below. You can nest `children` as many levels deep as you wish.
 
-Now let's ask Apostrophe to add the new locales to all of the existing docs in the database:
+**When you restart your Apostrophe node process or run a command line task such as `apostrophe-migrations:migrate**, Apostrophe will **automatically** add the new locales to all of the existing docs in the database.
+
+You may also do this explicitly:
 
 ```
 node app apostrophe-workflow:add-missing-locales
 ```
 
-By default, docs copied to new locales via this task will be considered trash in all locales except for the draft version of the default locale, until an editor chooses to clear the "trash" checkbox and then commit that change. If you prefer that that they be immediately live everywhere, use this command instead:
+By default, docs copied to new locales via this task will be considered trash in all live locales, until an editor chooses to commit them.  If you prefer that that they be immediately live everywhere, use this command instead:
 
 ```
 node app apostrophe-workflow:add-missing-locales --live
@@ -266,15 +263,19 @@ Two locales may have the same prefix, as long as they have different hostnames, 
 
 ### Adding prefixes to an existing database
 
-Apostrophe does not automatically add prefixes to existing slugs in your database when you enable prefixes for locales. You can do so with this command line task:
+**Prefixes are automatically added to page slugs when Apostrophe is restarted or you run a command line task,** such as `apostrophe-migrations:migrate`.
+
+You can also request this explicitly:
 
 ```
 node app apostrophe-workflow:add-locale-prefixes
 ```
 
-This is a one-time action.
+This is a one-time action. Prefixes are automatically added to new pages and when editing the "page settings" of old ones.
 
-There is currently no task to remove prefixes if you choose to stop using them. However, after the prefix configuration is removed, it becomes possible to edit the slug fully and remove the prefix by hand.
+**If you change or remove the prefix for a locale,** the change will take place for existing pages the next time you restart the site or run a task.
+
+> The editor may appear to allow removing the prefix from the slug, but it is always restored on save.
 
 ### If you only care about subdomains
 
@@ -289,12 +290,6 @@ Similarly, if all of your locales use prefixes which match the name of the local
 ### One login across all hostnames
 
 The workflow module provides single sign-on across all of the hostnames, provided that you use the locale picker provided by Apostrophe's editing interface to switch between them. The user's session cookie is transferred to the other hostname as part of following that link.
-
-You **do not** have to run this task again. It is a one-time transition.
-
-Currently there is no automated way to roll back to not having slug prefixes. However, if you disable the `prefixes` flag, the entire slug becomes editable again, and so you can manually remove them.
-
-*The editor may appear to allow removing the prefix from the slug, but it is always restored on save.*
 
 ## Tags and localization: we recommend using joins instead
 

--- a/apostrophe-workflow
+++ b/apostrophe-workflow
@@ -1,1 +1,0 @@
-/Users/boutell/src/apostrophe-workflow

--- a/apostrophe-workflow
+++ b/apostrophe-workflow
@@ -1,0 +1,1 @@
+/Users/boutell/src/apostrophe-workflow

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var async = require('async');
+
 var modules = [
   'apostrophe-workflow-areas',
   'apostrophe-workflow-docs',
@@ -70,7 +72,11 @@ module.exports = {
     self.enableHelpers();
     self.enableCrossDomainSessionCache();
     self.refineOptimizeKey();
-    return self.enableCollection(callback);
+    return async.series([
+      self.enableCollection,
+      self.enableFacts,
+      self.updateHistoricalPrefixes
+    ], callback);
   },
 
   construct: function(self, options) {

--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -127,6 +127,10 @@ module.exports = function(self, options) {
           // Ditto any parked page
         } else if (_doc.slug === 'global') {
           // The global doc
+        } else if (options.workflowDefaultLocaleNotTrash && (doc.workflowLocale === self.defaultLocale)) {
+          // In default locale, and we've received the flag to ensure that is not in the trash; this flag
+          // is used when adding workflow for the first time, because it is the sensible migration path
+          // for a site that did not have workflow before
         } else if ((options.workflowMissingLocalesLive === 'liveOnly') ||
           (self.isAncestorOf(doc.workflowLocale, _doc.workflowLocale) && _doc.workflowLocale.match(/-draft$/))) {
           // If it's a draft let it through matching the parent, otherwise

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -213,16 +213,16 @@ module.exports = function(self, options) {
   // for exports of the slug field to work reasonably.
 
   self.ensurePageSlugPrefix = function(doc) {
-    var allPrefixes = _.values(self.prefixes);
+    var allPrefixes = self.historicalPrefixes;
     var prefix = self.prefixes && self.prefixes[self.liveify(doc.workflowLocale)];
-    if (!(prefix && self.apos.pages.isPage(doc) && doc.workflowLocale)) {
+    if (!(self.apos.pages.isPage(doc) && doc.workflowLocale)) {
       return;
     }
     // Match the first component of the URL
     var matches = doc.slug && doc.slug.match(/^\/([^/]+)/);
     if (!matches) {
       // No first component or no slug at all
-      doc.slug = prefix + (doc.slug || '/' + self.apos.utils.slugify(doc.title));
+      doc.slug = (prefix || '') + (doc.slug || '/' + self.apos.utils.slugify(doc.title));
     } else {
       var existing = matches[1];
       if (('/' + existing) === prefix) {
@@ -230,10 +230,10 @@ module.exports = function(self, options) {
       } else if (_.contains(allPrefixes, '/' + existing)) {
         // There is another prefix present, this is an export of a slug change,
         // replace it
-        doc.slug = prefix + doc.slug.substr(existing.length + 1);
+        doc.slug = (prefix || '') + doc.slug.substr(existing.length + 1);
       } else {
         // There is no existing locale prefix
-        doc.slug = prefix + doc.slug;
+        doc.slug = (prefix || '') + doc.slug;
       }
     }
   };
@@ -764,6 +764,146 @@ module.exports = function(self, options) {
       }, callback);
     }
 
+  };
+
+  self.enableFacts = function(callback) {
+    return self.apos.db.collection('aposWorkflowFacts', function(err, facts) {
+      if (err) {
+        return callback(err);
+      }
+      self.facts = facts;
+      return callback(null);
+    });
+  };
+
+  // Run the specified function if the specified fact has changed. The fact is
+  // compared to its old value in the database using `_.isEqual()`. If there
+  // is no old value in the database this is treated as a change. The function
+  // receives `(oldFact, newFact, callback)` and must invoke the callback given to it.
+  // After this completes successfully, the fact's last known value is updated in the database.
+  //
+  // If `fn` reports an error, the callback receives that error and the fact's last
+  // known value is not updated.
+
+  self.ifFactChanged = function(name, newValue, fn, callback) {
+    return self.facts.findOne({ _id: name }, function(err, fact) {
+      if (err) {
+        return callback(err);
+      }
+      fact = fact && _.omit(fact, '_id');
+      if (_.isEqual(newValue, fact)) {
+        return callback(null);
+      }
+      return fn(fact, newValue, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        return self.facts.update({ _id: name }, newValue, { upsert: true }, callback);
+      });
+    });
+  };
+
+  // Return an object to be compared to a previous value in order
+  // to determine whether add-missing-locales and add-locale-prefixes should be run
+
+  self.getLocalesFact = function() {
+    var fact = {};
+    fact.locales = _.keys(self.locales);
+    fact.prefixes = self.prefixes;
+    return fact;
+  };
+
+  // Runs the add-missing-locales and add-locale-prefixes tasks at startup,
+  // if the relevant configuration has changed. Called for you by the
+  // page parking mechanism before pages are parked.
+
+  self.updatePerConfiguration = function(callback) {
+    return self.ifFactChanged('locales', self.getLocalesFact(), fixBody, callback);
+    function fixBody(oldFact, newFact, callback) {
+      return async.series([
+        addMissingLocales,
+        addLocalePrefixes
+      ], callback);
+      function addMissingLocales(callback) {
+        return self.addMissingLocalesTask(self.apos, self.apos.argv, callback);
+      }
+      function addLocalePrefixes(callback) {
+        return self.updateLocalePrefixes(oldFact, newFact, callback);
+      }
+    }
+  };
+
+  // Update all out of date locale prefixes. Requires
+  // the old and new values of self.getLocalesFact() to
+  // do this efficiently. If these arguments are omitted entirely,
+  // all pages are updated
+
+  self.updateLocalePrefixes = function(oldFact, newFact, callback) {
+    if (arguments.length === 1) {
+      // May omit facts
+      callback = oldFact;
+      oldFact = null;
+      newFact = null;
+    }
+    var req = self.apos.tasks.getReq();
+    return async.eachSeries(_.keys(self.locales), function(locale, callback) {
+      var criteria = {
+        $and: [
+          {
+            slug: /^\//,
+            workflowLocale: locale
+          }
+        ]
+      };
+      if (oldFact && newFact) {
+        var oldPrefix = oldFact.prefixes[self.liveify(locale)];
+        var newPrefix = newFact.prefixes[self.liveify(locale)];
+        if (oldPrefix === newPrefix) {
+          // No change for this specific locale
+          return setImmediate(callback);
+        }
+        if (oldPrefix && oldPrefix.length) {
+          criteria.$and.push({
+            slug: new RegExp('^' + self.apos.utils.regExpQuote(oldPrefix + '/'))
+          });
+        } else if (newPrefix && newPrefix.length) {
+          criteria.$and.push({
+            slug: {
+              $not: new RegExp('^' + self.apos.utils.regExpQuote(newPrefix + '/'))
+            }
+          });
+        } else {
+          // If not equal and neither has a length, it must be no change
+          // when considered as a string
+          return setImmediate(callback);
+        }
+      }
+      return self.apos.migrations.eachDoc(criteria, function(page, callback) {
+        return self.apos.pages.update(req, page, { permissions: false }, callback);
+      }, callback);
+    }, callback);
+  };
+
+  self.updateHistoricalPrefixes = function(callback) {
+    return async.series([
+      getHistoricalPrefixes,
+      updateHistoricalPrefixes
+    ], callback);
+
+    function getHistoricalPrefixes(callback) {
+      return self.facts.findOne({ _id: 'historicalPrefixes' }, function(err, historicalPrefixes) {
+        if (err) {
+          return callback(err);
+        }
+        self.historicalPrefixes = (historicalPrefixes && historicalPrefixes.prefixes) || [];
+        return callback(null);
+      });
+    }
+
+    function updateHistoricalPrefixes(callback) {
+      self.historicalPrefixes = _.union(self.historicalPrefixes, _.values(self.prefixes || {}));
+      return self.facts.update({ _id: 'historicalPrefixes' }, { prefixes: self.historicalPrefixes }, { upsert: true }, callback);
+    }
   };
 
 };

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -247,7 +247,6 @@ module.exports = {
         (self.apos.argv._[0] === 'apostrophe-workflow:add-missing-locales') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:add-locale-prefixes') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:remove-numbered-parked-pages') ||
-        (self.apos.argv._[0] === 'apostrophe-workflow:remove-numbered-parked-pages') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:harmonize-workflow-guids-by-parked-id')) {
         // If we park pages in this scenario, we'll wind up with
         // duplicate pages in the new locales after the task

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -239,11 +239,14 @@ module.exports = {
     };
 
     // `implementParkAll` must be reimplemented to cover all of
-    // the locales and to adjust the slugs if the prefixes option
-    // is in use
+    // the locales, and to first invoke the add-missing-locales and
+    // add-locale-prefixes logic, if needed
+
     self.implementParkAll = function(callback) {
-      if ((self.apos.argv._[0] === 'apostrophe-workflow:add-missing-locales') ||
+      if (
+        (self.apos.argv._[0] === 'apostrophe-workflow:add-missing-locales') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:add-locale-prefixes') ||
+        (self.apos.argv._[0] === 'apostrophe-workflow:remove-numbered-parked-pages') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:remove-numbered-parked-pages') ||
         (self.apos.argv._[0] === 'apostrophe-workflow:harmonize-workflow-guids-by-parked-id')) {
         // If we park pages in this scenario, we'll wind up with
@@ -252,27 +255,14 @@ module.exports = {
         return setImmediate(callback);
       }
 
-      var locked = false;
+      var workflow = self.apos.modules['apostrophe-workflow'];
 
-      return async.series([ lock, park ], function(err) {
-        if (locked) {
-          return self.apos.locks.unlock('apostrophe-pages:parked', function(_err) {
-            return callback(err || _err);
-          });
-        }
-        return callback(err);
-      });
+      return async.series([
+        workflow.updatePerConfiguration,
+        parkBody
+      ], callback);
 
-      function lock(callback) {
-        return self.apos.locks.lock('apostrophe-pages:parked', function(err) {
-          if (!err) {
-            locked = true;
-          }
-          return callback(err);
-        });
-      }
-
-      function park(callback) {
+      function parkBody(callback) {
         var workflow = self.apos.modules['apostrophe-workflow'];
         var locales = _.keys(workflow.locales);
         return async.eachSeries(locales, function(locale, callback) {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -37,18 +37,46 @@ module.exports = function(self, options) {
     );
   };
 
-  self.addMissingLocalesTask = function(apos, argv, callback) {
-    var req = self.apos.tasks.getReq();
-    return async.series([
-      fixIndexes,
-      noLocales,
-      missingSomeLocalesDraft,
-      missingSomeLocalesLive,
-      resolve,
-      fixPermissions
-    ], function(err) {
+  // Run the given function inside the apostrophe-pages:parked lock, which
+  // in the presence of workflow is the general purpose lock for major
+  // overhauls of aposDocs. The function must take a callback.
+
+  self.withLock = function(fn, callback) {
+    var locked = false;
+
+    return async.series([ lock, fn ], function(err) {
+      if (locked) {
+        return self.apos.locks.unlock('apostrophe-pages:parked', function(_err) {
+          return callback(err || _err);
+        });
+      }
       return callback(err);
     });
+    function lock(callback) {
+      return self.apos.locks.lock('apostrophe-pages:parked', function(err) {
+        if (err) {
+          return callback(err);
+        }
+        locked = true;
+        return callback(null);
+      });
+    }
+  };
+
+  self.addMissingLocalesTask = function(apos, argv, callback) {
+    var req = self.apos.tasks.getReq();
+    return self.withLock(fix, callback);
+
+    function fix(callback) {
+      return async.series([
+        fixIndexes,
+        noLocales,
+        missingSomeLocalesDraft,
+        missingSomeLocalesLive,
+        resolve,
+        fixPermissions
+      ], callback);
+    }
 
     function fixIndexes(callback) {
       var old;
@@ -180,13 +208,7 @@ module.exports = function(self, options) {
   };
 
   self.addLocalePrefixesTask = function(apos, argv, callback) {
-    var req = self.apos.tasks.getReq();
-    return self.apos.migrations.eachDoc({ slug: /^\// }, function(page, callback) {
-      if (!self.includeType(page.type)) {
-        return setImmediate(callback);
-      }
-      return self.apos.pages.update(req, page, { permissions: false }, callback);
-    }, callback);
+    return self.updateLocalePrefixes(callback);
   };
 
   self.removeNumberedParkedPagesTask = function(apos, argv, callback) {


### PR DESCRIPTION
When next you restart your app or run a command line task, Apostrophe detects the configuration change and runs the relevant tasks. In addition, add-locale-prefixes was rewritten to provide more optimal performance and avoid unnecessary work, and add-locale-prefixes is now smart enough to remove a prefix if you decide a locale shouldn't have one anymore.