### PR TITLE
Cannot see locale subsettings for a permission when you first reopen permissions tab

### DIFF
--- a/lib/modules/apostrophe-workflow-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-workflow-schemas/public/js/user.js
@@ -246,11 +246,11 @@ apos.define('apostrophe-schemas', {
       function reflect() {
         _.each(field.choices, function(choice) {
           var $choice = $fieldset.find('[data-apos-permission="' + choice.value + '"]');
-          var $tree = $choice.find('.apos-workflow-locale-tree');
+          var $tree = $choice.find('.apos-workflow-locale-tree:first');
           if ($choice.find('[value="' + choice.value + '"]:checked').length) {
-            $tree.show();
+            $tree.addClass('apos-workflow-locale-tree--active');
           } else {
-            $tree.hide();
+            $tree.removeClass('apos-workflow-locale-tree--active');
           }
         });
       }

--- a/lib/modules/apostrophe-workflow-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-workflow-schemas/public/js/user.js
@@ -246,7 +246,7 @@ apos.define('apostrophe-schemas', {
       function reflect() {
         _.each(field.choices, function(choice) {
           var $choice = $fieldset.find('[data-apos-permission="' + choice.value + '"]');
-          var $tree = $choice.find('.apos-workflow-locale-tree:first');
+          var $tree = $choice.find('.apos-workflow-locale-tree');
           if ($choice.find('[value="' + choice.value + '"]:checked').length) {
             $tree.addClass('apos-workflow-locale-tree--active');
           } else {

--- a/public/css/user.less
+++ b/public/css/user.less
@@ -155,6 +155,9 @@
   }
   .apos-workflow-locale-tree {
     display: none;
+    &.apos-workflow-locale-tree--active {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
If workflow is active and you have already granted the "edit" permission to a group, then upon re-editing that group you should see the locale selections for that permission right away. Right now you don't and you have to toggle it off and on again to see them.