### PR TITLE
eliminated $or queries from the workflow module

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,14 +651,11 @@ However, if you need to work directly with MongoDB while respecting a specific l
 {
   $and: [
     {
-      $or: [
-        {
-          workflowLocale: 'en'
-        },
-        {
-          workflowLocale: { $exists: 0 }
-        }
-      ]
+      workflowLocale: {
+        $in: [
+          'en', null
+        ]
+      }
     },
     {
       // YOUR OWN CRITERIA GO HERE

--- a/lib/modules/apostrophe-workflow-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-workflow-docs/lib/cursor.js
@@ -31,7 +31,6 @@ module.exports = {
             // no criteria needed
           }
         } else {
-          // console.log('generic');
           // Content not participating in localization will have no locale at all,
           // take care not to block access to that. However we can use `$in`,
           // which works just like the equality filter and will accept `null` as

--- a/lib/modules/apostrophe-workflow-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-workflow-docs/lib/cursor.js
@@ -22,9 +22,27 @@ module.exports = {
         } else {
           // It's an explicit locale string
         }
-        // Content not participating in localization will have no locale at all,
-        // take care not to block access to that
-        self.and({ $or: [ { workflowLocale: setting }, { workflowLocale: { $exists: 0 } } ] });
+        if (self.get('type')) {
+          if (workflow.includeType(self.get('type'))) {
+            // query is restricted by type to a type that definitely involves workflow
+            self.and({ workflowLocale: setting });
+          } else {
+            // Restricted by type to a type that definitely does not involve workflow,
+            // no criteria needed
+          }
+        } else {
+          // console.log('generic');
+          // Content not participating in localization will have no locale at all,
+          // take care not to block access to that. However we can use `$in`,
+          // which works just like the equality filter and will accept `null` as
+          // a match for "property does not exist at all". This avoids a slow
+          // $or query
+          self.and({
+            workflowLocale: {
+              $in: [ setting, null ]
+            }
+          });
+        }
       }
     });
 

--- a/test/testApi.js
+++ b/test/testApi.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var async = require('async');
 var revertId;
 
-describe('Workflow Core', function() {
+describe('Workflow API', function() {
   this.timeout(5000);
   var apos;
 


### PR DESCRIPTION
$or queries are considered a bad smell in MongoDB and are slow in some cases.

Surprisingly in the general case, in simple test code without the full complexity of the Apostrophe query, performance was similar with $in versus $or, and explain() revealed that MongoDB was able to reduce it to a single query with two sets of index bounds, same as $in.

However it is possible this optimization is defeated in more complex queries. And, I was also able to use a pure equality test or no test at all in cases where the type filter is in play. That is a significant win.

Test code for simple cases showing the results mentioned above:

```
(function() {
  db.dropDatabase();
  db.docs.ensureIndex({ size: 1, workflowLocale: 1 });
  const docs = [];
  const locales = [ 'en', 'en-draft', 'fr', 'fr-draft', 'de', 'de-draft' ];

  for (let i = 0; (i < 50000); i++) {
    const which = Math.floor(Math.random() * (locales.length + 1));
    const doc = {
      size: Math.floor(Math.random() * 5),
      title: 'wacky wacky willickers the third'
    };
    if (which === locales.length) {
      // no locale, it is a type that does not need one      
    } else {
      doc.workflowLocale = locales[which];
    }
    docs.push(doc);
  }
  db.docs.insert(docs);
})();

print("first count, then run explain for en only\n");
data(db.docs.count({ size: 1, workflowLocale: 'en' }));
data(db.docs.find({ size: 1, workflowLocale: 'en' }).explain("executionStats"));

print("first count, then run explain for $in approach\n");
data(db.docs.count({ size: 1, workflowLocale: { $in: [ 'en', null ] } }));
data(db.docs.find({ size: 1, workflowLocale: { $in: [ 'en', null ] } }).explain("executionStats"));

print("first count, then run explain for $or approach\n");
data(db.docs.count({ size: 1,             $or: [
              {
                workflowLocale: { $exists: 0 }
              },
              {
                workflowLocale: 'en'
              }
            ]
 }));
data(db.docs.find({ size: 1,            $or: [
              {
                workflowLocale: { $exists: 0 }
              },
              {
                workflowLocale: 'en'
              }
            ]
 }).explain("executionStats"));


function data(o) {
  print(JSON.stringify(o, null, '  ') + '\n');
}
```