### PR TITLE
Documentation: added an index to the README, restructured headings a little bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,59 @@
 
 The `apostrophe-workflow` module adds powerful workflow and localization capabilities to Apostrophe. As a workflow system it provides for a draft version of every document, so that changes do not immediately "go live." As a localization system it provides for documents to exist in several locales, allowing for easy internationalization.
 
-We'll begin with the steps needed simply to add workflow to your project. Then we'll examine the changes needed for localization (also known as internationalization).
+We'll begin with the steps needed simply to add workflow to your project. Then we'll examine the changes needed for localization (also known as i18n or internationalization).
 
-## npm
+- [Before getting started](#user-content-before-getting-started)
+  - [Adding `parkedId` to your parked pages](#user-content-adding-parkedid-to-your-parked-pages)
+  - [Adding workflow to your database](#user-content-adding-workflow-to-your-database)
+- [Using the workflow feature](#user-content-using-the-workflow-feature)
+  - [Private locales and default locale](#user-content-private-locales-and-default-locale)
+  - ["Why am I asked to commit so many things?"](#user-content-why-am-i-asked-to-commit-so-many-things)
+  - [Workflow for pieces](#user-content-workflow-for-pieces)
+  - [Workflow for page settings](#user-content-workflow-for-page-settings)
+- [Using the localization feature](#user-content-using-the-localization-feature)
+  - [Private locales](#user-content-private-locales)
+  - [Document structure for locales](#user-content-document-structure-for-locales)
+  - [Setting the lang attribute](#user-content-setting-the-lang-attribute)
+  - [Building a locale picker on the front end](#user-content-building-a-locale-picker-on-the-front-end)
+  - [Exporting between locales](#user-content-exporting-between-locales)
+    - [Forcing exports](#user-content-forcing-exports)
+    - [Forcing export of one widget](#user-content-forcing-export-of-one-widget)
+  - [Switching locales via custom hostnames and/or prefixes](#user-content-switching-locales-via-custom-hostnames-andor-prefixes)
+    - [Adding prefixes to an existing database](#user-content-adding-prefixes-to-an-existing-database)
+    - [If you only care about subdomains](#user-content-if-you-only-care-about-subdomains)
+    - [If you only care about prefixes](#user-content-if-you-only-care-about-prefixes)
+    - [One login across all hostnames](#user-content-one-login-across-all-hostnames)
+  - [Tags and localization: we recommend using joins instead](#user-content-tags-and-localization-we-recommend-using-joins-instead)
+  - [Workflow with permissions: limiting who can do what](#user-content-workflow-with-permissions-limiting-who-can-do-what)
+    - [Setting up the site: enabling group management](#user-content-setting-up-the-site-enabling-group-management)
+  - [Locale-specific stylesheets](#user-content-locale-specific-stylesheets)
+  - [An overview of permissions](#user-content-an-overview-of-permissions)
+    - [Locales for permissions](#user-content-locales-for-permissions)
+    - [Permissions tutorial](#user-content-permissions-tutorial)
+  - [Accessing newly created pages in other locales](#user-content-accessing-newly-created-pages-in-other-locales)
+  - [Aliasing the module](#user-content-aliasing-the-module)
+  - [Previewing piece types without an index page](#user-content-previewing-piece-types-without-an-index-page)
+- [Command line tasks and workflow](#user-content-command-line-tasks-and-workflow)
+  - [Using the --workflow-locale option](#user-content-using-the---workflow-locale-option)
+  - [Setting the current locale programmatically](#user-content-setting-the-current-locale-programmatically)
+- [Direct MongoDB access and workflow](#user-content-direct-mongodb-access-and-workflow)
+- [setPropertiesAcrossLocales: modifying a document programmatically across locales](#user-content-setpropertiesacrosslocales-modifying-a-document-programmatically-across-locales)
+- [Writing safe afterInsert and docAfterInsert handlers etc.](#user-content-writing-safe-afterinsert-and-docafterinsert-handlers-etc)
+- [Technical approach](#user-content-technical-approach)
+  - [Use of jsondiffpatch](#user-content-use-of-jsondiffpatch)
+  - [Patching and exporting of widgets](#user-content-patching-and-exporting-of-widgets)
+- [Legacy task: cleaning up duplicate homepages](#user-content-legacy-task-cleaning-up-duplicate-homepages)
+
+## Before getting started
+
+Start by installing apostrophe-workflow.
 
 ```
 npm install --save apostrophe-workflow
 ```
 
-## app.js
-
-In `app.js`, configure the `apostrophe-workflow` module with the rest. We'll start with a simple configuration just providing workflow:
+Then configure the `apostrophe-workflow` module in `app.js` with the rest of your modules. We'll start with a simple configuration just providing workflow:
 
 ```
 'apostrophe-workflow': {
@@ -22,11 +64,11 @@ In `app.js`, configure the `apostrophe-workflow` module with the rest. We'll sta
 }
 ```
 
-## Adding `parkedId` to your parked pages
+### Adding `parkedId` to your parked pages
 
 If you are using the `park` option with `apostrophe-pages`, and you have not already set a unique `parkedId` property for each page specified for that option, **do so before you start using workflow.** This will address problems that otherwise occur if slugs change due to locale prefixes.
 
-## Adding workflow to your database
+### Adding workflow to your database
 
 Odds are, you already have a database. Either from an existing project, or for a new one, since Apostrophe creates the database on the very first run. So, follow these steps to add workflow to your database.
 
@@ -53,31 +95,31 @@ node app apostrophe-users:add admin admin
 node app apostrophe-workflow:add-missing-locales --live
 ```
 
-## Using Workflow
+## Using the workflow feature
 
 This basic configuration provides you with a live/draft toggle on the page (lower left corner). Editing is not possible in the live mode. You will not see most types of pieces in the admin bar, and you will not see editing controls on the page. This is normal.
 
 In the draft mode, editing works in a familiar way. Your changes are constantly saved, just like before, but they are only saved to the draft version of the document.
 
-When you are satisfied, click "submit" to submit your work for review by someone else, or "commit" to commit it to the live version of the page yourself. 
+When you are satisfied, click "submit" to submit your work for review by someone else, or "commit" to commit it to the live version of the page yourself.
 
 If work is submitted that you have permission to edit, you can view a list of those pages and pieces via the "Workflow" admin bar menu.
 
-## "Why am I asked to commit so many things?"
+### "Why am I asked to commit so many things?"
 
 When you click "Commit" on the page, all of the documents that make up what you see on the page need to be committed in order to go live on the site. That includes the images in a slideshow, the blog posts in a blog widget, and so on. It may seem like a lot of work the first time. Just remember that you won't be asked to commit them again unless their drafts have been updated.
 
-## Workflow for pieces
+### Workflow for pieces
 
 "Pieces," like blog posts or events, work just like before. However, just make sure you enter "draft" mode; until you do that most piece types won't show up on the admin bar, because you can only edit the draft version directly.
 
 When you are finished editing a piece, use the "workflow" menu in the upper right corner of the dialog box to select "submit" or "commit."
 
-## Workflow for page settings
+### Workflow for page settings
 
 Workflow also applies to page settings, such as the title. You can easily toggle between displaying the draft and live versions of the title while in the page settings dialog box. And, you can submit or commit via the workflow dropdown menu in the upper right corner of the dialog box.
 
-## Localizing and internationalizing websites
+## Using the localization feature
 
 To enable localization, configure more than one locale in `app.js`:
 
@@ -113,13 +155,17 @@ To enable localization, configure more than one locale in `app.js`:
 
 If you have worked with localization before you will recognize locale names like `en-gb`. These are arbitrary; you may choose any name. However, if you plan to use URL prefixes to distinguish between locales (see below), you must choose a hyphenated, lower-case name without punctuation. So we suggest that you always do that.
 
-> "What about the `default` locale? What does `private` do?" Private locales cannot actually be accessed by the public. Although it isn't mandatory, we recommend setting up a private `default` locale for the "master copy" of your content, written in your team's most familiar language, and then exporting content to child locales.
->
-> **If you use private locales, you *must* give the "view private locales" permission to any Apostrophe groups that should be able to see those locales when logged in. This is a simple permission that can be granted to a group via the "Groups" option on the admin bar or, if you are using hardcoded groups, via the "groups" option to the `apostrophe-users` module (the latter requires a restart to push the new permission). If you're using workflow, it's probably a good idea to comment out the `groups` option, which allows you to manage your groups through Apostrophe's interface instead.
->
-> Note that if you do not have a locale named `default`, you must set the `defaultLocale` option to the name of a locale you do have. Also note that if you started out with no locales for simple workflow, Apostrophe already created a `default` locale implicitly. Leaving that out of your locale configuration would give you no way to access the existing content.
->
-> The parent-child relationship between locales is just a convenience for quickly exporting content to them, as you'll see below. You can nest `children` as many levels deep as you wish.
+### Private locales and default locale
+
+What about the `default` locale? What does `private` do? Private locales cannot actually be accessed by the public. Although it isn't mandatory, we recommend setting up a private `default` locale for the "master copy" of your content, written in your team's most familiar language, and then exporting content to child locales.
+
+**If you use private locales, you *must* give the "view private locales" permission to any Apostrophe groups that should be able to see those locales when logged in.** This is a simple permission that can be granted to a group via the "Groups" option on the admin bar or, if you are using hardcoded groups, via the "groups" option to the `apostrophe-users` module (the latter requires a restart to push the new permission). If you're using workflow, it's probably a good idea to comment out the `groups` option, which allows you to manage your groups through Apostrophe's interface instead.
+
+Note that if you do not have a locale named `default`, you must set the `defaultLocale` option to the name of a locale you do have. Also note that if you started out with no locales for simple workflow, Apostrophe already created a `default` locale implicitly. Leaving that out of your locale configuration would give you no way to access the existing content.
+
+The parent-child relationship between locales is just a convenience for quickly exporting content to them, as you'll see below. You can nest `children` as many levels deep as you wish.
+
+### Document structure for locales
 
 **When you restart your Apostrophe node process or run a command line task such as `apostrophe-migrations:migrate**, Apostrophe will **automatically** add the new locales to all of the existing docs in the database.
 
@@ -141,7 +187,7 @@ Now access the site as an administrator. You will be able to click on the curren
 
 Note that a single document may have a different slug in different locales. The slugs may also be the same, but you'll typically want to enable locale-specific prefixes, locale-specific domain names or a combination of the two as described below.
 
-## Setting the `lang` attribute
+### Setting the `lang` attribute
 
 Multilingual websites should set the `lang` attribute of the `html` element appropriately.
 
@@ -159,7 +205,7 @@ By default, this helper converts a string like `en-gb` to `en`, and leaves a str
 If this is not sufficient for your needs, you may set the `lang` property when configuring each
 locale, and that value will be output directly.
 
-## Building a locale picker on the front end
+### Building a locale picker on the front end
 
 Here's how to code a locale picker on the front end:
 
@@ -184,27 +230,27 @@ This code:
 
 May be omitted if you are using the `subdomains` feature or the `prefixes` feature. If you are using neither, then a query parameter is necessary as the slugs could be the same across locales. However the query parameter is automatically removed after the new locale is stored in the user's session.
 
-## Exporting between locales
+### Exporting between locales
 
 After committing a change, you will be invited to export that change to other locales. If you do so, it is applied as a "patch" to the other locale's draft (it is not made live right away).
 
 This allows for editors fluent in the other locale to complete any necessary translation tasks before finally committing the changes for that locale.
 
-### Not all patches can be exported
+#### Not all patches can be exported
 
 If the page has been altered greatly in structure, for example if the rich text widget on a page has been removed and replaced, making it effectively a separate widget altogether, then an edit to that widget will not take effect as a patch. It is a best practice to initially create all content in a "default" locale and then export it to others.
 
-## Forcing exports
+### Forcing exports
 
 If you need to, you can force an export of a document so that it is copied directly to the draft version in other locales. To do that, choose "Force Export" from the dialog box for the piece in question, or from the "Page Settings" dialog box for a page.
 
 > Even a forced export only alters the draft version of the other locales. Work must still be reviewed and committed there.
 
-## Forcing export of one widget
+### Forcing export of one widget
 
 You can also force the export of a single widget. You can do that via the new export button, displayed along with the up and down arrows, edit pencil and trash icon. This will always push that widget to the draft version of the document in other locales, as long as it can be found there.
 
-## Switching locales via custom hostnames and/or prefixes
+### Switching locales via custom hostnames and/or prefixes
 
 You'll want URLs to be different between locales so that there is no ambiguity when a user shares them.
 
@@ -267,7 +313,7 @@ Two locales may have the same prefix, as long as they have different hostnames, 
     }
 ```
 
-### Adding prefixes to an existing database
+#### Adding prefixes to an existing database
 
 **Prefixes are automatically added to page slugs when Apostrophe is restarted or you run a command line task,** such as `apostrophe-migrations:migrate`.
 
@@ -283,33 +329,33 @@ This is a one-time action. Prefixes are automatically added to new pages and whe
 
 > The editor may appear to allow removing the prefix from the slug, but it is always restored on save.
 
-### If you only care about subdomains
+#### If you only care about subdomains
 
 As a convenience, if *all* of your locales use subdomains which *match the name of the locale*, you may set `subdomains: true` and skip the `hostnames` option.
 
-### If you only care about prefixes
+#### If you only care about prefixes
 
 Similarly, if all of your locales use prefixes which match the name of the locale, you may set `prefixes: true` rather than passing an object that spells out the prefixes for each locale.
 
 > Of course, if you use the `hostnames` or `subdomains` option, your front end proxy must actually be configured to forward traffic for those hostnames.
 
-### One login across all hostnames
+#### One login across all hostnames
 
 The workflow module provides single sign-on across all of the hostnames, provided that you use the locale picker provided by Apostrophe's editing interface to switch between them. The user's session cookie is transferred to the other hostname as part of following that link.
 
-## Tags and localization: we recommend using joins instead
+### Tags and localization: we recommend using joins instead
 
 Tags in Apostrophe follow the typical MongoDB approach of a simple array property containing strings. They are localized like other fields. Thus if they are used to select content for display it is important to be consistent when translating tags to a particular locale.
 
 When working with localization it may be preferable to avoid tags in favor of joins. A `joinByOne` or `joinByArray` relationship can be used to relate a document to various "categories," which are localized documents in their own right and therefore behave consistently across locales. `apostrophe-workflow` will ensure that exported joins referencing a category in one locale are correctly adjusted to point to the equivalent category in the other locale.
 
-## Workflow with permissions: limiting who can do what
+### Workflow with permissions: limiting who can do what
 
 The workflow module supports permissions. This tutorial breaks down how to go about setting up a site with permissions and then creating permissions groups for particular locales. We'll then add new users to each of those groups and experiment with what they can and can't do.
 
 These features are helpful when a large team manages a site together. If your team is small and everyone might potentially work on everything, you might not choose to use these features.
 
-### Setting up the site: enabling group management
+#### Setting up the site: enabling group management
 
 First, launch your site with the usual `groups` setting for the `apostrophe-users` module, or with this minimal one:
 
@@ -341,13 +387,13 @@ Then, **remove the `groups` option or comment it out:**
 
 Now restart the site. This will enable the user interface in the admin bar for managing groups. (We plan to add command-line tasks for creating an admin group as an alternative to temporarily setting the `groups` option.)
 
-#### Removing the legacy groups
+##### Removing the legacy groups
 
 If you set up the site with the typical `admin`, `guest` and `editor` groups, but your plan is to give out permissions for specific locales to specific groups of people, you may wish to remove the `editor` group. You can do that via the "groups" button in the admin bar. Removing the `guest` group is optional; some find it useful for simple intranet pages.
 
 **Do not remove the `admin` group.** You need it to log in with full privileges.
 
-### Locale-specific stylesheets
+#### Locale-specific stylesheets
 
 Basic support for locale-specific stylesheets is provided. You may, if you wish, specify a stylesheet name for a locale. The primary purpose of such a stylesheet is to define font face imports and other global items, so that the regular LESS CSS build of Apostrophe can then use a consistent `font-family` setting for all locales but will in fact receive the correct actual font.
 
@@ -377,7 +423,7 @@ You may also define a `defaultStylesheet` to be pushed to all locales that do no
 
 Since we specified `stylesheet: 'cn'` for the `cn` locale, the project-level file `/lib/modules/apostrophe-workflow/public/css/cn.css` will be served to the browser. For all other locales, `/lib/modules/apostrophe-workflow/public/sss/default.css` will be served, because `defaultStylesheet` was also set.
 
-It will be delivered via a special Express route and the URL will target that route. The URL will be unique to the current asset generation and locale. 
+It will be delivered via a special Express route and the URL will target that route. The URL will be unique to the current asset generation and locale.
 
 > The file will not be part of a minified, CDN-delivered asset bundle. However, site-relative URLs (those beginning with `/`) will be rewritten to account for Apostrophe's `prefix` option and/or the use of an asset bundle in a CDN. Other types of relative URLs currently are not supported here. If you need to reference assets in the `public` folder of a module, use `/modules/modulename`, prefixing `modulename` with `my-` if it is in the project level `public` folder of an Apostrophe core or npm module.
 
@@ -385,65 +431,65 @@ This file will be pushed via a **separate `link` element in the `head`,** prior 
 
 This file currently **WILL NOT** be compiled with LESS, and it **MAY NOT** set LESS variables for other stylesheets to honor. Again, its primary purpose is to declare font face imports in a way that does not require excessive imports that are not needed in other locales.
 
-### An overview of permissions
+#### An overview of permissions
 
 Permissions are an important issue when working with workflow and locales. First we'll review all of the permissions you're sure to have questions about. Then we'll look at selecting locales for each permission and what that allows us to do.
 
-#### The "Editor" permission
+##### The "Editor" permission
 
 If you give this permission to a group, members of the group can *create and edit their own* pieces of any type, except for admin-only types like users and groups. In addition they are *candidates* to edit pages, but only if they are given permission explicitly for that page. If you do not need to distinguish between permissions for one piece type and another, this can be convenient.
 
-#### The "Admin: All" permission
+##### The "Admin: All" permission
 
 Do not give this permission to a group unless you want them to have **total control**, including making more users and giving groups more permissions.
 
 **This permission does not present a choice of locales,** because it provides **total control** of the website.
 
-#### "View Private Locales"
+##### "View Private Locales"
 
 This permission restricts access to locales that are marked with `private: true`. These are the locales that the general public cannot access. Often a `default` locale is the parent of all other locales and the public cannot see it. You should generally give this permission to any group that has editing privileges on the site.
 
-#### "Upload and Crop"
+##### "Upload and Crop"
 
 This permission is required to upload attachments to the site. You should generally give it to any group that has editing privileges on the site.
 
-#### The "Admin: Global" permission
+##### The "Admin: Global" permission
 
 This refers to the shared "global" document that is often used for shared headers and footers that appear on every page of a site. If you wish a group to be able to edit this, give them the "Admin: Global" permission.
 
-#### The "Edit: Global" permission (do not use)
+##### The "Edit: Global" permission (do not use)
 
 The "Edit: Global" permission exists because the global document is technically a piece, but will be hidden in the interface soon. Users can't create their own new "global" doc, so this permission is not useful. See "Admin: Global" instead.
 
-#### "Admin: Pages": total control of pages
+##### "Admin: Pages": total control of pages
 
 If you give this permission to a group, members of the group can edit all of the pages on the site, subject to locale restrictions, as we'll see in a moment.
 
-#### "Edit: Pages": candidates to edit pages
+##### "Edit: Pages": candidates to edit pages
 
 If you give this permission to a group, members of the group are *candidates* to edit pages, but only if they are given permission explicitly for that page. They can also create subpages at that point, and will have permission to edit those as well.
 
-#### "Admin: Article": total control of articles
+##### "Admin: Article": total control of articles
 
 Users with this permission have complete control of articles (blog post pieces, as configured in the sandbox project).
 
-#### "Edit: Article": creating and editing their own articles
+##### "Edit: Article": creating and editing their own articles
 
 Users with this permission can create and edit their own articles. They usually cannot edit anyone else's, unless custom edit permissions for pieces are specifically enabled (see the pieces module documentation).
 
-#### "Admin: Image": total control of articles
+##### "Admin: Image": total control of articles
 
 Users with this permission have complete control of images (the image pieces that the `apostrophe-images` widget displays).
 
-#### "Edit: Image": creating and editing their own images
+##### "Edit: Image": creating and editing their own images
 
 Users with this permission can add and edit their own images on the site. They cannot typically edit anyone else's, although it is possible to enable custom edit permissions for pieces (see the pieces module documentation). You will usually want to give any group with editing permissions access to edit images.
 
-#### "Edit: File": creating and editing their own files
+##### "Edit: File": creating and editing their own files
 
 Just like "Edit: Images", but for files such as PDFs, typically used with the apostrophe-files widget.
 
-### Locales for permissions
+#### Locales for permissions
 
 After you check the box for a permission, you will be presented with a choice of locales. There is a dropdown menu for each one.
 
@@ -457,13 +503,13 @@ If you set it to "commit," then members of the group can *both* edit the draft *
 
 > If you are only using this module for workflow and have not set up multiple locales, you will still need to set the dropdown for the "default" locale to "edit" or "commit" for each permission.
 
-### Permissions tutorial
+#### Permissions tutorial
 
 This tutorial assumes you have configured a `default` parent locale and `en` and `fr` child locales. We also assume you are working with our sandbox project, which has the blog module configured with the label "Articles."
 
 Our goal is to enable a certain group of people to edit, but not commit, the `en` locale, and another group of people to commit their changes, making them live. That second group should also be able to export those changes as new drafts in the `fr` locale.
 
-#### Creating the fr-editors group
+##### Creating the fr-editors group
 
 Log in as the admin user. Click on the admin bar. Click "Groups."
 
@@ -482,13 +528,13 @@ We recommend you check these boxes:
 
 After you check each of the last four, you will see dropdowns allowing you to pick a level of control for each locale. For "fr," pick "Edit." Leave the rest set to "None."
 
-#### Creating an "fr-editor" user
+##### Creating an "fr-editor" user
 
 Next, click on "Users" in the admin bar. Add an "fr-editor" user. Make them a member of the "fr-editors" group by clicking the "Browse" button for "Groups." It works just like editing any other relationship in Apostrophe.
 
 Save the user and move on to the next step.
 
-#### Creating the "fr-committers" group
+##### Creating the "fr-committers" group
 
 Now we'll want a group with permission to commit changes to "fr," and also export them, as drafts, to the "en" locale to explore that feature.
 
@@ -507,13 +553,13 @@ For each one, the list of locales will appear again. For "fr", pick "commit." Fo
 
 > "Why Admin: rather than Edit: this time?" Because this allows us to edit pieces that were created by **other people**. It also gives us access to all of the pages on the site for the specified locales. If you don't want this — if you want to be more restrictive, and give out permission page by page to this group — you can choose "Edit: Pages." Conversely, you can specify "Admin: Pages" for the "fr-editors" group if you wish to skip giving out permissions to them page by page.
 
-#### Creating an "fr-comitter" user
+##### Creating an "fr-comitter" user
 
 Next, click on "Users" in the admin bar. Add an "fr-committer" user. Much like before, make them a member of the "fr-committers" group by clicking the "Browse" button for "Groups."
 
 Save the user and move on to the next step.
 
-#### Granting editing permissions on the home page
+##### Granting editing permissions on the home page
 
 Now, as the admin user, switch from "Live" to "Draft." Then click "Page Menu" and "Page Settings." Now click the "Permissions" tab.
 
@@ -523,19 +569,19 @@ When the option appears, set "Apply to Subpages" to "Yes." This will perform a *
 
 Now save your work. Permissions for the home page have been pushed to the two new groups.
 
-#### Working with the "fr-editors" account
+##### Working with the "fr-editors" account
 
 Next, log out, or use an incognito window, separate browser, or separate user identity in Chrome.
 
 Now log in as "fr-editor".
 
-**Unless `fr` is the default locale, you won't have any editing privileges right away.** That's because we only gave them out for the `fr` locale. Click "Locales" and pick "fr". 
+**Unless `fr` is the default locale, you won't have any editing privileges right away.** That's because we only gave them out for the `fr` locale. Click "Locales" and pick "fr".
 
 Now you'll see edit buttons on the home page and you can edit it normally. You can also click "Submit" to request review. But, you can't commit the page.
 
 Similarly, when you edit "Articles" via the admin bar, you can submit them, but you cannot commit them. So, you can't make changes live on your own.
 
-#### Working with the "fr-committers" account
+##### Working with the "fr-committers" account
 
 Now use another browser identity, or log out, and log back in as "fr-committer".
 
@@ -545,11 +591,11 @@ This time, you'll notice a "commit" button on the home page. And, you'll find th
 
 Commit changes to make them live for the home page, and you'll see that as a logged-out site visitor you are now able to see them, provided that you have implemented a way for logged-out users to switch to the `fr` locale.
 
-#### Exporting
+##### Exporting
 
 After you commit a change, such as on the home page, you'll be offered the usual option to export the change. And, as "fr-committer", you will be able to check the box to export to "en" (English). However, if any other locales are present, you will not be able to check those boxes. That's because we did not give the "fr-committers" group "edit" access to those locales for pages.
 
-### Accessing newly created pages in other locales
+#### Accessing newly created pages in other locales
 
 Often a page or piece is created solely for use in a single locale. Technically, the page or piece exists in *every* locale. However, to avoid clutter, it is initially "trash" in other locales. So how do we make those pieces and pages live in other locales when we wish to?
 
@@ -559,7 +605,7 @@ For pages, it is almost as straightforward. Click on "Pages" in the admin bar to
 
 As with pieces, change "Trash" to "No." The "Trash" field will be located right after the "Published" field. When you click save, the page will be live in this locale.
 
-### Aliasing the module
+#### Aliasing the module
 
 By default, optional modules like `apostrophe-workflow` do not have an alias. That means you can't just type `apos.workflow` to access them.
 
@@ -581,7 +627,7 @@ However, in the suggested examples above, we assume you have done this when enab
 
 If you are using that alias for another module in your project, all of the examples above will still work. Just replace any references to `apos.workflow` with a different alias and configure that alias for the module.
 
-### Previewing piece types without an index page
+#### Previewing piece types without an index page
 
 The preview iframe displayed by the commit and history review modals works with regular pages and also with pieces that can be displayed on a page via a pieces index page, such as a blog.
 
@@ -616,7 +662,7 @@ You can change this by adding the `--workflow-locale` option to your command lin
 node app my-module:my-task --workflow-locale=en
 node app my-module:my-task --workflow-locale=en-draft
 ```
-    
+
 Note that you *must add the `-draft` suffix* if you want to target draft content, not live content.
 
 ### Setting the current locale programmatically
@@ -744,7 +790,7 @@ For best results, **all** implementations of Apostrophe callbacks should wait to
 For 2.x, the draft and live versions of a doc are completely separate docs as far as most of Apostrophe is concerned. A `workflowGuid` property ties them together. This greatly reduces the scope of changes required in the rest of Apostrophe and improves performance by removing the need to move content around on every page view or load content for locales you are not looking at.
 
 As the term locale suggests, the 2.x workflow module also implements localization of content by introducing paired live and draft locales for each country or culture you wish to support.
-  
+
 ### Use of jsondiffpatch
 
 This module relies somewhat on `jsondiffpatch` to calculate diffs between commits and offer a patch to be applied to the drafts of other locales. `jsondiffpatch` is also used to visualize differences in the commit modal.


### PR DESCRIPTION
The docs for this module are great! However, it feels like they have grown organically over time, and at this point they are long enough to make them somewhat hard to navigate. I think we could do even more to give the different sections a clearer order and better structure, but this PR is just a simple effort to add an index to the top of the docs to make it easier to navigate them. I gave the index a tree structure in different levels, which is why I also "downgraded" the level of some headings (eg. from an `h3` to an `h4`).