### PR TITLE
option to disable export after commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ After committing a change, you will be invited to export that change to other lo
 
 This allows for editors fluent in the other locale to complete any necessary translation tasks before finally committing the changes for that locale.
 
+#### If you find this option appears too frequently
+
+Do you export rarely? If so, you may want to set the `exportAfterCommit` option of the `apostrophe-workflow` module to `false`.
+
+If you do so, the "export" dialog box will not appear right after every commit. Instead the user must choose to access it. The option can be found on the "workflow" dropdown menu, accessed via "Page Settings" or via the editing dialog box for any piece type, including "global."
+
 #### Not all patches can be exported
 
 If the page has been altered greatly in structure, for example if the rich text widget on a page has been removed and replaced, making it effectively a separate widget altogether, then an edit to that widget will not take effect as a patch. It is a best practice to initially create all content in a "default" locale and then export it to others.

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -328,7 +328,8 @@ module.exports = function(self, options) {
       locale: req.locale,
       nestedLocales: self.nestedLocales,
       prefixes: self.prefixes,
-      hostnames: self.hostnames
+      hostnames: self.hostnames,
+      exportAfterCommit: self.options.exportAfterCommit
     };
   };
 

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -91,7 +91,7 @@ module.exports = {
           (workflow.localized && (verb === 'edit'))
             ? [
               {
-                label: 'History',
+                label: 'History and Export',
                 action: 'workflow-history'
               }
             ] : []

--- a/public/js/commit-modal.js
+++ b/public/js/commit-modal.js
@@ -29,7 +29,7 @@ apos.define('apostrophe-workflow-commit-modal', {
           if (result.status !== 'ok') {
             return callback(result.status);
           }
-          if (result.locales.length > 1) {
+          if ((apos.modules['apostrophe-workflow'].options.exportAfterCommit !== false) && (result.locales.length > 1)) {
             return self.manager.export(commitId, callback);
           }
           return callback(null);


### PR DESCRIPTION
An enterprise request, see zd 2759. When this option is enabled by setting `exportAfterCommit` explicitly to `false`, the export modal does not appear right after the commit modal. Instead you must access it via the workflow dropdown menu of "page settings" or the pieces editor modal. To facilitate discovering the feature, the "History" item on that dropdown is now labeled "History and Export." (Exporting any commit, including but not limited to the latest one, has always been an option when viewing the history modal.)

This solution addresses the desires of customers who use export more rarely, with a minimum of new code.
