### PR TITLE
Show draft docs that have been trashed but not yet committed in commit modal by default

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -783,22 +783,22 @@ module.exports = function(self, options) {
         return callback(err);
       }
 
-      self.getEditable(req, untrashedLiveDocIds, {}, callback);
+      return self.getEditable(req, untrashedLiveDocIds, {}, callback);
     });
 
     function getTrashedDraftDocs(callback) {
-      self.apos.docs.find(req, {}, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, docs) {
+      return self.apos.docs.find(req, {}, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, docs) {
         if (err) {
           return callback(err);
         }
 
         workflowGuids = _.pluck(docs, 'workflowGuid');
-        callback();
+        return callback();
       });
     }
 
     function getUntrashedLiveDocs(callback) {
-      self.apos.docs.find(req, {
+      return self.apos.docs.find(req, {
         workflowGuid: { $in: workflowGuids },
         // We avoid calling the workflowLocale cursor filter, because that
         // method will include doc types that are excluded from
@@ -810,7 +810,7 @@ module.exports = function(self, options) {
         }
 
         untrashedLiveDocIds = _.pluck(docs, '_id');
-        callback();
+        return callback();
       });
     }
   };

--- a/lib/api.js
+++ b/lib/api.js
@@ -771,29 +771,48 @@ module.exports = function(self, options) {
   // docs, which means that the callback is called with the same signature
   // `(null, modified, unmodified, committable)`
 
-  self.getTrashed = function(req, callback) {
-    return self.apos.docs.find(req, {}, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, draftDocs) {
+  self.getUncommittedTrash = function(req, callback) {
+    var workflowGuids;
+    var untrashedLiveDocIds;
+
+    return async.series([
+      getTrashedDraftDocs,
+      getUntrashedLiveDocs
+    ], function(err) {
       if (err) {
         return callback(err);
       }
 
-      var workflowGuids = _.pluck(draftDocs, 'workflowGuid');
+      self.getEditable(req, untrashedLiveDocIds, {}, callback);
+    });
 
-      return self.apos.docs.find(req, {
+    function getTrashedDraftDocs(callback) {
+      self.apos.docs.find(req, {}, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, docs) {
+        if (err) {
+          return callback(err);
+        }
+
+        workflowGuids = _.pluck(docs, 'workflowGuid');
+        callback();
+      });
+    }
+
+    function getUntrashedLiveDocs(callback) {
+      self.apos.docs.find(req, {
         workflowGuid: { $in: workflowGuids },
         // We avoid calling the workflowLocale cursor filter, because that
         // method will include doc types that are excluded from
         // apostrophe-workflow
         workflowLocale: self.liveify(req.locale)
-      }, { _id: 1 }).permission('edit').published(null).workflowLocale(null).toArray(function(err, liveDocs) {
+      }, { _id: 1 }).permission('edit').published(null).workflowLocale(null).toArray(function(err, docs) {
         if (err) {
           return callback(err);
         }
 
-        var ids = _.pluck(liveDocs, '_id');
-        self.getEditable(req, ids, {}, callback);
+        untrashedLiveDocIds = _.pluck(docs, '_id');
+        callback();
       });
-    });
+    }
   };
 
   // Fetch joins, load areas, etc. on doc objects that came out of the

--- a/lib/api.js
+++ b/lib/api.js
@@ -785,7 +785,7 @@ module.exports = function(self, options) {
         // method will include doc types that are excluded from
         // apostrophe-workflow
         workflowLocale: self.liveify(req.locale)
-      }, { _id: 1 }).published(null).workflowLocale(null).toArray(function(err, liveDocs) {
+      }, { _id: 1 }).permission('edit').published(null).workflowLocale(null).toArray(function(err, liveDocs) {
         if (err) {
           return callback(err);
         }

--- a/lib/api.js
+++ b/lib/api.js
@@ -766,6 +766,36 @@ module.exports = function(self, options) {
     return callback(null, result);
   };
 
+  // Retrieve all documents where the draft version has been trashed, but the
+  // live version has not. This method will call `self.getEditable` on the found
+  // docs, which means that the callback is called with the same signature
+  // `(null, modified, unmodified, committable)`
+
+  self.getTrashed = function(req, callback) {
+    return self.apos.docs.find(req, {}, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, draftDocs) {
+      if (err) {
+        return callback(err);
+      }
+
+      var workflowGuids = _.pluck(draftDocs, 'workflowGuid');
+
+      return self.apos.docs.find(req, {
+        workflowGuid: { $in: workflowGuids },
+        // We avoid calling the workflowLocale cursor filter, because that
+        // method will include doc types that are excluded from
+        // apostrophe-workflow
+        workflowLocale: self.liveify(req.locale)
+      }, { _id: 1 }).published(null).workflowLocale(null).toArray(function(err, liveDocs) {
+        if (err) {
+          return callback(err);
+        }
+
+        var ids = _.pluck(liveDocs, '_id');
+        self.getEditable(req, ids, {}, callback);
+      });
+    });
+  };
+
   // Fetch joins, load areas, etc. on doc objects that came out of the
   // commits collection. Used for previewing.
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -686,18 +686,18 @@ module.exports = function(self, options) {
     });
   });
 
-  self.route('post', 'trashed', function(req, res) {
+  self.route('post', 'uncommitted-trash', function(req, res) {
     if (!req.user) {
       return res.status(404).send('notfound');
     }
-    return self.getTrashed(req, function(err, modified, unmodified, committable) {
+    return self.getUncommittedTrash(req, function(err, modified, unmodified, committable) {
       if (err) {
         self.apos.utils.error(err);
         return res.send({ status: 'error' });
       }
       return res.send({
         status: 'ok',
-        trashed: _.pluck(modified, '_id'),
+        uncommittedTrash: _.pluck(modified, '_id'),
         committable: _.pluck(committable, '_id')
       });
     });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -669,7 +669,7 @@ module.exports = function(self, options) {
       return res.status(404).send('notfound');
     }
     var ids = self.apos.launder.ids(req.body.ids);
-    return self.getEditable(req, ids, { related: true }, function(err, modified, unmodified, committable) {
+    return self.getEditable(req, ids, { related: req.body.related }, function(err, modified, unmodified, committable) {
       if (err) {
         self.apos.utils.error(err);
         return res.send({ status: 'error' });
@@ -681,7 +681,24 @@ module.exports = function(self, options) {
         committable: _.pluck(committable, '_id'),
         unsubmitted: _.pluck(_.filter(modified, function(doc) {
           return ((!doc.workflowSubmitted) || (doc.workflowSubmitted.username !== req.user.username));
-        }))
+        }), '_id')
+      });
+    });
+  });
+
+  self.route('post', 'trashed', function(req, res) {
+    if (!req.user) {
+      return res.status(404).send('notfound');
+    }
+    return self.getTrashed(req, function(err, modified, unmodified, committable) {
+      if (err) {
+        self.apos.utils.error(err);
+        return res.send({ status: 'error' });
+      }
+      return res.send({
+        status: 'ok',
+        trashed: _.pluck(modified, '_id'),
+        committable: _.pluck(committable, '_id')
       });
     });
   });

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -146,7 +146,7 @@ apos.define('apostrophe-workflow', {
       var uncommittedTrash;
       var editable;
 
-      async.series([
+      return async.series([
         getUncommittedTrash,
         getEditable
       ], function(error) {
@@ -175,12 +175,12 @@ apos.define('apostrophe-workflow', {
             // actually be avoided.
             ids = result.uncommittedTrash.concat(ids);
             uncommittedTrash = result.uncommittedTrash;
-            callback(null);
+            return callback(null);
           } else {
-            callback(result.status);
+            return callback(result.status);
           }
         }, function(error) {
-          callback(error);
+          return callback(error);
         });
       }
 
@@ -188,12 +188,12 @@ apos.define('apostrophe-workflow', {
         self.api('editable', _.assign({ ids: ids }, options), function(result) {
           if (result.status === 'ok') {
             editable = result;
-            callback();
+            return callback();
           } else {
-            callback(result.status);
+            return callback(result.status);
           }
         }, function(error) {
-          callback(error);
+          return callback(error);
         });
       }
     };

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -70,7 +70,7 @@ apos.define('apostrophe-workflow', {
         // The submit procedure should only affect edited docs, it shouldn't
         // consider documents that have been trashed (even if they technically
         // haven't been submitted)
-        var unsubmitted = _.difference(result.unsubmitted, result.trashed);
+        var unsubmitted = _.difference(result.unsubmitted, result.uncommittedTrash);
 
         setClass($menu, 'apos-workflow-editable', result.modified.length || result.unmodified.length);
         setClass($menu, 'apos-workflow-modified', !!result.modified.length);
@@ -125,14 +125,14 @@ apos.define('apostrophe-workflow', {
     // list to include only editable docs. The callback
     // receives `(null, result)` on success. `result` has
     // `modified`, `unmodified`, `committable`, `submitted`
-    // and `trashed` properties, which are arrays of ids of
-    // draft documents, all of which are editable and may in
-    // some way appear on the current page.
+    // and `uncommittedTrash` properties, which are arrays of
+    // ids of draft documents, all of which are editable and
+    // may in some way appear on the current page.
     //
-    // If `options.trashed` is falsy, then we avoid looking
-    // up trashed draft docs that haven't been committed and
-    // no `trashed` property is included in `result`. This option
-    // is `true` by default.
+    // If `options.uncommittedTrash` is falsy, then we avoid
+    // looking up trashed draft docs that haven't been committed
+    // and no `uncommittedTrash` property is included in `result`.
+    // However this option is `true` by default.
     //
     // If `options.related` is truthy then related documents,
     // i.e. related via joins or widgets, are also included.
@@ -141,41 +141,40 @@ apos.define('apostrophe-workflow', {
     // considered rather than those found on the page.
 
     self.getEditable = function(options, callback) {
-      options = _.assign({ trashed: true }, options);
+      options = _.assign({ uncommittedTrash: true }, options);
       var ids = options.ids || self.getDocIds();
-      var trashed;
+      var uncommittedTrash;
+      var editable;
 
       async.series([
-        getTrashed,
+        getUncommittedTrash,
         getEditable
-      ], function(error, results) {
+      ], function(error) {
         if (error) {
           return callback(error);
         }
 
-        var result = results[1];
-
-        if (trashed) {
-          result.trashed = trashed;
+        if (uncommittedTrash) {
+          editable.uncommittedTrash = uncommittedTrash;
         }
 
-        callback(null, result);
+        callback(null, editable);
       });
 
-      function getTrashed(callback) {
-        if (!options.trashed) {
+      function getUncommittedTrash(callback) {
+        if (!options.uncommittedTrash) {
           return callback(null);
         }
 
-        self.api('trashed', {}, function(result) {
+        self.api('uncommitted-trash', {}, function(result) {
           if (result.status === 'ok') {
-            // We ask editors to commit trashed docs first by putting those ids
-            // before the edited doc ids. That's because trashed docs have their
-            // slugs updated to avoid collisions with non-trashed docs, but
+            // We ask editors to commit uncommittedTrash docs first by putting those ids
+            // before the edited doc ids. That's because uncommittedTrash docs have their
+            // slugs updated to avoid collisions with non-uncommittedTrash docs, but
             // those new slugs need to be committed for that conflict to
             // actually be avoided.
-            ids = result.trashed.concat(ids);
-            trashed = result.trashed;
+            ids = result.uncommittedTrash.concat(ids);
+            uncommittedTrash = result.uncommittedTrash;
             callback(null);
           } else {
             callback(result.status);
@@ -188,7 +187,8 @@ apos.define('apostrophe-workflow', {
       function getEditable(callback) {
         self.api('editable', _.assign({ ids: ids }, options), function(result) {
           if (result.status === 'ok') {
-            callback(null, result);
+            editable = result;
+            callback();
           } else {
             callback(result.status);
           }
@@ -213,7 +213,7 @@ apos.define('apostrophe-workflow', {
     self.enableSubmit = function() {
       $('body').on('click', '[data-apos-workflow-submit]', function() {
         apos.ui.globalBusy(true);
-        self.getEditable({ related: true, trashed: false }, function(err, result) {
+        self.getEditable({ related: true, uncommittedTrash: false }, function(err, result) {
           apos.ui.globalBusy(false);
           if (!err) {
             self.submit(result.modified);


### PR DESCRIPTION
This addresses https://github.com/apostrophecms/apostrophe/issues/1641.

When an editor trashes a document, that only affects the draft version of that document. From a developer standpoint, this makes sense, since the `trash` property is just another property on the doc in the database. For the editor however, the document has effectively disappeared from the site now, and it's common for them not to be aware of the fact that they will need to find the document in the piece modal and manually commit it from there for it to actually be removed from the live site.

This commit changes that so that apostrophe-workflow by default looks up docs where the draft version has been trashed and the live version has not when editors commit a document. This makes it easy and obvious that trashed documents need to be committed to actually disappear.

Have to say I was fairly pleased with how neat this changed turned out! It introduces an additional delay when bringing up the commit modal (since we're calling an additional server endpoint), but I didn't see any obvious methods for improving that.