### PR TITLE
Feature/allow one non prefixed locale with shared host

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -175,6 +175,28 @@ module.exports = function(self, options) {
       _.assign(self.prefixes, self.options.prefixes);
     }
 
+    // Run the following check only if hostnames or prefixes
+    // have been configured.
+    if (self.hostnames || self.prefixes) {
+      var rootPaths = {};
+      _.each(self.locales, function (props, locale) {
+        // Keep draft locales out of the tests
+        if (!(/-draft$/).test(locale)) {
+          // Since both hostnames and prefixes are optional,
+          // placeholders are provided to effectively check
+          // if the per-locale configuration is unique. This
+          // also handles the exception case where one locale
+          // can exist at the root level of a shared hostname.
+          var root = (self.hostnames && _.has(self.hostnames, locale) ? self.hostnames[locale] : 'default-hostname-placeholder') + (self.prefixes && _.has(self.prefixes, locale) ? self.prefixes[locale] : '/');
+
+          if (_.has(rootPaths, root)) {
+            throw new Error(`apostrophe-workflow: locales must have a unique combination of hostname and prefix. The locales ${rootPaths[root]} and ${locale} are currently configured to use the same hostname and the same prefix (${root}).`);
+          } else {
+            rootPaths[root] = locale;
+          }
+        }
+      });
+    }
   };
 
   // Ensure the given doc has a `workflowLocale` property; if not

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -175,9 +175,9 @@ module.exports = function(self, options) {
       _.assign(self.prefixes, self.options.prefixes);
     }
 
-    // Run the following check only if hostnames or prefixes
-    // have been configured.
-    if (self.hostnames || self.prefixes) {
+    // Run the following check only if hostnames and prefixes
+    // have both been configured.
+    if (self.hostnames && self.prefixes) {
       var rootPaths = {};
       _.each(self.locales, function (props, locale) {
         // Keep draft locales out of the tests

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -85,6 +85,12 @@ module.exports = function(self, options) {
         }
       }
 
+      function extractRootLevelLocale(candidates) {
+        return _.filter(candidates, function (candidate) {
+          return !_.has(self.prefixes, candidate);
+        });
+      }
+
       // If we're not down to one yet, winnow it down by prefix
       if ((candidates.length > 1) && self.prefixes) {
         // If we're dealing with a locale which shares the hostname
@@ -95,16 +101,31 @@ module.exports = function(self, options) {
           // a locale which resides at the root level of a shared
           // hostname won't have a prefix. So we select the candidate
           // which doesn't have a prefix in this case.
-          candidates = _.filter(candidates, function(candidate) {
-            return !_.has(self.prefixes, candidate);
-          });
+          candidates = extractRootLevelLocale(candidates);
         } else {
           matches = req.url.match(/^\/[^/]+/);
           if (matches) {
             prefix = matches[0];
-            candidates = _.filter(candidates, function (candidate) {
+
+            var filteredCandidates = _.filter(candidates, function (candidate) {
               return self.prefixes[candidate] === prefix;
             });
+
+            // At this stage, if the list of filtered candidates is
+            // empty, it means the first fragment of the URI didn't
+            // match any of the candidates' locale prefixes. Note that
+            // we're here because the hostname filter did not narrow
+            // the candidates to one, so this is likely to be a URI
+            // for a root-level locale among candidates filtered by
+            // hostname.
+            if (filteredCandidates.length === 0) {
+              candidates = extractRootLevelLocale(candidates);
+            } else {
+              // if the candidates list isn't empty, the URI's first fragment
+              // matched the locale prefix for one of the candidates, in which
+              // case it's fairly clear how to proceed.
+              candidates = filteredCandidates;
+            }
           }
         }
       }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -87,12 +87,25 @@ module.exports = function(self, options) {
 
       // If we're not down to one yet, winnow it down by prefix
       if ((candidates.length > 1) && self.prefixes) {
-        matches = req.url.match(/^\/[^/]+/);
-        if (matches) {
-          prefix = matches[0];
+        // If we're dealing with a locale which shares the hostname
+        // with other locales, but doesn't have a prefix, (i.e. it
+        // exists at the root level of the hostname), figure out
+        // that locale and set that as the current session's locale.
+        if (req.url === '/') {
+          // a locale which resides at the root level of a shared
+          // hostname won't have a prefix. So we select the candidate
+          // which doesn't have a prefix in this case.
           candidates = _.filter(candidates, function(candidate) {
-            return self.prefixes[candidate] === prefix;
+            return !_.has(self.prefixes, candidate);
           });
+        } else {
+          matches = req.url.match(/^\/[^/]+/);
+          if (matches) {
+            prefix = matches[0];
+            candidates = _.filter(candidates, function (candidate) {
+              return self.prefixes[candidate] === prefix;
+            });
+          }
         }
       }
 

--- a/test/test2.js
+++ b/test/test2.js
@@ -40,15 +40,21 @@ describe('Workflow Subdomains and Prefixes', function() {
             'default': 'example.com',
             'us': 'example.com',
             'us-en': 'example.com',
-            'us-es': 'example.com'
+            'us-es': 'example.com',
+            'es': 'example.es',
+            'es-CO': 'example.es',
+            'es-MX': 'example.es'
           },
           prefixes: {
             // Even private locales must be distinguishable by hostname and/or prefix
             'default': '/default',
-            'us': '/us',
-
-            'us-en': '/en',
-            'us-es': '/es'
+            'us': '/us-private',
+            // we don't add a prefix for us-en since that locale
+            // will reside at the root level and share the hostname
+            // with us-es and us-fr.
+            'us-es': '/es',
+            'es-CO': '/co',
+            'es-MX': '/mx'
             // We don't need prefixes for fr because
             // that hostname is not shared with other
             // locales
@@ -71,6 +77,17 @@ describe('Workflow Subdomains and Prefixes', function() {
                     },
                     {
                       name: 'us-es'
+                    }
+                  ]
+                },
+                {
+                  name: 'es',
+                  children: [
+                    {
+                      name: 'es-CO'
+                    },
+                    {
+                      name: 'es-MX'
                     }
                   ]
                 }
@@ -121,9 +138,30 @@ describe('Workflow Subdomains and Prefixes', function() {
     });
   });
 
-  it('can find a jointly-determined locale via middleware', function(done) {
+  it('can find a jointly-determined locale via middleware - case 1', function(done) {
     tryMiddleware('http://example.com/es', function(req) {
       assert(req.locale === 'us-es');
+      done();
+    });
+  });
+
+  it('can find a jointly-determined locale via middleware - case 2', function (done) {
+    tryMiddleware('http://example.es/co', function (req) {
+      assert(req.locale === 'es-CO');
+      done();
+    });
+  });
+
+  it('can detect a root-level locale via middleware - case 1', function(done) {
+    tryMiddleware('http://example.com', function(req) {
+      assert(req.locale === 'us-en');
+      done();
+    });
+  });
+
+  it('can detect a root-level locale via middleware - case 2', function (done) {
+    tryMiddleware('http://example.es', function (req) {
+      assert(req.locale === 'es');
       done();
     });
   });
@@ -593,7 +631,13 @@ describe('Workflow Subdomains and Prefixes', function() {
       'us-en',
       'us-en-draft',
       'us-es',
-      'us-es-draft'
+      'us-es-draft',
+      'es',
+      'es-draft',
+      'es-CO',
+      'es-CO-draft',
+      'es-MX',
+      'es-MX-draft'
     ];
     assert(_.isEqual(locales, $in));
   });

--- a/test/test2.js
+++ b/test/test2.js
@@ -41,9 +41,12 @@ describe('Workflow Subdomains and Prefixes', function() {
             'us': 'example.com',
             'us-en': 'example.com',
             'us-es': 'example.com',
+            'us-de': 'example.com',
             'es': 'example.es',
             'es-CO': 'example.es',
-            'es-MX': 'example.es'
+            'es-MX': 'example.es',
+            'de': 'example.de',
+            'de-de': 'example.de'
           },
           prefixes: {
             // Even private locales must be distinguishable by hostname and/or prefix
@@ -53,8 +56,10 @@ describe('Workflow Subdomains and Prefixes', function() {
             // will reside at the root level and share the hostname
             // with us-es and us-fr.
             'us-es': '/es',
+            'us-de': '/de',
             'es-CO': '/co',
-            'es-MX': '/mx'
+            'es-MX': '/mx',
+            'de-de': '/de'
             // We don't need prefixes for fr because
             // that hostname is not shared with other
             // locales
@@ -77,6 +82,9 @@ describe('Workflow Subdomains and Prefixes', function() {
                     },
                     {
                       name: 'us-es'
+                    },
+                    {
+                      name: 'us-de'
                     }
                   ]
                 },
@@ -88,6 +96,14 @@ describe('Workflow Subdomains and Prefixes', function() {
                     },
                     {
                       name: 'es-MX'
+                    }
+                  ]
+                },
+                {
+                  name: 'de',
+                  children: [
+                    {
+                      name: 'de-de'
                     }
                   ]
                 }
@@ -160,8 +176,36 @@ describe('Workflow Subdomains and Prefixes', function() {
   });
 
   it('can detect a root-level locale via middleware - case 2', function (done) {
+    tryMiddleware('http://example.com/some-url', function (req) {
+      assert(req.locale === 'us-en');
+      done();
+    });
+  });
+
+  it('can detect a root-level locale via middleware - case 3', function (done) {
     tryMiddleware('http://example.es', function (req) {
       assert(req.locale === 'es');
+      done();
+    });
+  });
+
+  it('can detect a root-level locale via middleware - case 4', function (done) {
+    tryMiddleware('http://example.es/some-url', function (req) {
+      assert(req.locale === 'es');
+      done();
+    });
+  });
+
+  it('can differentiate between locales which differ by hostname, but share a prefix - case 1', function (done) {
+    tryMiddleware('http://example.com/de', function (req) {
+      assert(req.locale === 'us-de');
+      done();
+    });
+  });
+
+  it('can differentiate between locales which differ by hostname, but share a prefix - case 2', function (done) {
+    tryMiddleware('http://example.de/de', function (req) {
+      assert(req.locale === 'de-de');
       done();
     });
   });
@@ -632,12 +676,18 @@ describe('Workflow Subdomains and Prefixes', function() {
       'us-en-draft',
       'us-es',
       'us-es-draft',
+      'us-de',
+      'us-de-draft',
       'es',
       'es-draft',
       'es-CO',
       'es-CO-draft',
       'es-MX',
-      'es-MX-draft'
+      'es-MX-draft',
+      'de',
+      'de-draft',
+      'de-de',
+      'de-de-draft'
     ];
     assert(_.isEqual(locales, $in));
   });


### PR DESCRIPTION
This feature will allow sets of locales to share a hostname, with one locale from each set having the ability to exist at the root of the hostname. This is allowed for cases where a website may have a locale configuration which places the home page of each locale as follows,

'en' - example.com, (English - Generic)
'en-UK' - example.com/uk, (English - UK)
'en-DE' - example.com/de, (English - Germany)
'de' - example.de, (German - Generic)
'de-CH' - example.de/ch (German - Switzerland).

This configuration doesn't require a prefix for the 'en' and the 'de' locales. However, it requires a prefix for all other locales sharing the hostnames of these two root-level locales.

An extra check has been added to the `composeOptions` method to ensure that the hostname/prefix configuration satisfies the above conditions. This check will throw an error in cases where the configuration results in a conflict between two locales.