### PR TITLE
Add trailing slash to URL when redirecting visitors to locale homepage

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -170,7 +170,7 @@ module.exports = function(self, options) {
 
       if (self.prefixes && self.prefixes[self.liveify(req.locale)] && (req.url === '/')) {
         // Redirect to home page of appropriate locale
-        return res.redirect(self.prefixes[self.liveify(req.locale)]);
+        return res.redirect(self.prefixes[self.liveify(req.locale)] + '/');
       }
 
       return next();


### PR DESCRIPTION
Even though we intend to redirect visitors to the homepage of a locale in this particular location in the code, we didn't append a trailing slash to the locale prefix, which meant that visitors had to go through
an additional redirect.

Previously visitors would go from example.com -> example.com/uk -> example.com/uk/. With this change, they go directly from example.com -> example.com/uk/.