### PR TITLE
Removed migration that belongs in apostrophe proper, also more verbose info about what's going on during add-missing-locales

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -50,16 +50,24 @@ module.exports = function(self, options) {
     return self.withLock(fix, callback);
 
     function fix(callback) {
+      self.apos.utils.info('add-missing-locales in progress');
       return async.series([
         fixIndexes,
         noLocales,
         missingSomeLocalesDraft,
         missingSomeLocalesLive,
         resolve
-      ], callback);
+      ], function(err) {
+        if (err) {
+          return callback(err);
+        }
+        self.apos.utils.info('add-missing-locales completed');
+        return callback(null);
+      });
     }
 
     function fixIndexes(callback) {
+      self.apos.utils.info('Fixing indexes...');
       var old;
       return async.series([
         getOld,
@@ -111,6 +119,7 @@ module.exports = function(self, options) {
     }
 
     function noLocales(callback) {
+      self.apos.utils.info('Fixing documents with no locales...');
       return self.apos.migrations.eachDoc({ workflowLocale: { $exists: 0 } }, 5, function(doc, callback) {
         if (!self.includeType(doc.type)) {
           return setImmediate(callback);
@@ -124,18 +133,19 @@ module.exports = function(self, options) {
     }
 
     function missingSomeLocalesDraft(callback) {
-
+      self.apos.utils.info('Fixing documents missing some locales in draft...');
       return self.addMissingLocales(req, { workflowMissingLocalesSubset: 'draft' }, callback);
 
     }
 
     function missingSomeLocalesLive(callback) {
-
+      self.apos.utils.info('Fixing documents missing some locales in live...');
       return self.addMissingLocales(req, { workflowMissingLocalesSubset: 'live' }, callback);
 
     }
 
     function resolve(callback) {
+      self.apos.utils.info('Resolving deferred join relationships efficiently...');
       return self.resolveDeferredRelationships(callback);
     }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -55,8 +55,7 @@ module.exports = function(self, options) {
         noLocales,
         missingSomeLocalesDraft,
         missingSomeLocalesLive,
-        resolve,
-        fixPermissions
+        resolve
       ], callback);
     }
 
@@ -140,24 +139,6 @@ module.exports = function(self, options) {
       return self.resolveDeferredRelationships(callback);
     }
 
-    function fixPermissions(callback) {
-      var fields = [ 'viewUsersIds', 'viewGroupsIds',
-        'editUsersIds', 'editGroupsIds',
-        'viewUsersRelationships', 'viewGroupsRelationships',
-        'editUsersRelationships', 'editGroupsRelationships'
-      ];
-      return async.eachSeries(fields, function(field, callback) {
-        var criteria = {};
-        criteria[field] = { $type: 10 };
-        var $set = {};
-        $set[field] = [];
-        self.apos.docs.db.update(criteria, {
-          $set: $set
-        }, {
-          multi: true
-        }, callback);
-      }, callback);
-    }
   };
 
   self.resolveJoinIdsTask = function(apos, argv, callback) {


### PR DESCRIPTION
See also https://github.com/apostrophecms/apostrophe/pull/1696