### PR TITLE
Avoid excluding private locales in extractRootLevelLocale function

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -87,8 +87,7 @@ module.exports = function(self, options) {
 
       function extractRootLevelLocale(candidates) {
         return _.filter(candidates, function (candidate) {
-          const locale = self.locales[candidate];
-          return (!locale.private) && (!_.has(self.prefixes, candidate));
+          return !_.has(self.prefixes, candidate);
         });
       }
 


### PR DESCRIPTION
Previously, if the root locale of a hostname was private, we could end up in a situation where no locale would be matched. This could lead to a situation where locales could be accessed from the wrong hostname, since visitors already have a locale saved in their session (and that's the final thing that we read to set `req.locale`).

This should be reproducible with the following config:

```js
{
    hostnames: {
        fi: 'www.example.fi',
        'sv-fi': 'www.example.fi'
        no: 'www.example.com',
        se: 'www.example.com',
    },
    prefixes: {
        no: '/no',
        se: '/se',
        'sv-fi': '/se'
    },
    locales: [
        { name: 'fi', label: 'Finland', private: true },
        { name: 'sv-fi', label: 'Swedish (Finland)' },
        { name: 'no', label: 'Norway' },
        { name: 'se', label: 'Sweden' },
    ]
}
```

If I visit `http://www.example.fi/no`, then I wouldn't get a 404 (or be redirected to `http://www.example.com/no`), but instead the Norwegian locale would be served as if I was on example.com.

This change defers the private locale check further down the chain (which I believe is a more logical place for it to live).