### PR TITLE
change i18n locale when changing locale in workflow

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -15,6 +15,13 @@ module.exports = function(self, options) {
     middleware: function(req, res, next) {
       var to, host, matches, locale, prefix, hostname, subdomain, domain, candidates;
 
+      function setLocale(locale) {
+        req.session.locale = locale;
+        if (self.apos.hasOwnProperty('i18n')) {
+          self.apos.i18n.setLocale(req,locale);
+        }
+      }
+
       req.data = req.data || {};
       req.data.workflow = req.data.workflow || {};
       _.assign(req.data.workflow, _.pick(self, 'locales', 'nestedLocales'));
@@ -48,8 +55,9 @@ module.exports = function(self, options) {
       if (req.query.workflowLocale) {
         // Switch locale choice in session via query string, then redirect
         locale = self.apos.launder.string(req.query.workflowLocale);
+
         if (_.has(self.locales, locale)) {
-          req.session.locale = locale;
+          setLocale(locale);
         }
         if (self.hostnames) {
           // Don't let a stale hostname just switch it back
@@ -143,7 +151,7 @@ module.exports = function(self, options) {
 
       // If we made it down to one locale, that's the winner
       if (candidates.length === 1) {
-        req.session.locale = candidates[0];
+        setLocale(candidates[0]);
       }
       req.locale = req.session.locale;
 
@@ -155,7 +163,7 @@ module.exports = function(self, options) {
         (self.locales[req.locale].private && (!self.apos.permissions.can(req, 'private-locales')))) {
 
         self.guessLocale(req);
-        req.session.locale = req.locale;
+        setLocale(req.locale);
       }
 
       if (req.user) {


### PR DESCRIPTION
A simple solution to sync i18n with workflow module.
I know you have a branch yet to create a i18n bridge module to avoid copy locales in i18n module conf, but this is a simple working solution, if you configure both modules.
