### PR TITLE
 if a type is exempt from workflow, do not complain that the locale i…

### DIFF
--- a/lib/modules/apostrophe-workflow-permissions/index.js
+++ b/lib/modules/apostrophe-workflow-permissions/index.js
@@ -29,6 +29,11 @@ module.exports = {
         return;
       }
 
+      // Types excluded from workflow should not be subject to any of this
+      if (!workflow.includeType(info.type)) {
+        return;
+      }
+
       // Flunk any access to a nonexistent locale or, if
       // we don't have the private-locale permission,
       // any access to a private locale
@@ -54,9 +59,6 @@ module.exports = {
       }
       var manager = self.apos.docs.getManager(info.type);
       if (!manager) {
-        return;
-      }
-      if (!workflow.includeType(info.type)) {
         return;
       }
       var verb = info.verb;


### PR DESCRIPTION
…s inaccessible to the editor