### PR TITLE
Implements dgad 602: movement in the page tree should be subject to workflow, should not automatically affect all locales at once, should have normal permissions

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -165,6 +165,54 @@ module.exports = function(self, options) {
     }
   };
 
+  // Repeat the most recent move operation in the page tree
+  // that took place for `from` in the locale of `to`
+  self.repeatMove = function(req, from, to, callback) {
+    if (!from.workflowMoved) {
+      return callback(null);
+    }
+    let targetId;
+    return async.series([
+      getTargetId,
+      move
+    ], function(err) {
+      if (err === 'notfound') {
+        self.apos.notify(req, 'The most recent move of the page in the tree could not be duplicated as part of the commit.');
+        err = null;
+      }
+      return callback(null);
+    });
+    function getTargetId(callback) {
+      return self.apos.docs.db.findOne({ workflowGuid: from.workflowMoved.target, workflowLocale: to.workflowLocale }, { _id: 1 }, function(err, info) {
+        if (err) {
+          return callback(err);
+        }
+        targetId = info._id;
+        if (!targetId) {
+          return callback('notfound');
+        }
+        return callback(null);
+      });
+    }
+    function move(callback) {
+      console.log(to._id, targetId, from.workflowMoved.position);
+      self.apos.pages.move(req,
+        to._id,
+        targetId,
+        from.workflowMoved.position,
+        {
+          criteria: {
+            workflowLocale: to.workflowLocale
+          },
+          filters: {
+            workflowLocale: to.workflowLocale
+          }
+        },
+        callback
+      );
+    }
+  };
+
   // Invokes resolveRelationships for all docs that have the
   // workflowResolveDeferred: true property, and removes the property.
   //
@@ -217,7 +265,8 @@ module.exports = function(self, options) {
       _.partial(self.resolveRelationships, req, to, to.workflowLocale),
       insertCommit,
       _.partial(self.updateViaManager, req, to),
-      clearSubmitted
+      move,
+      clearSubmittedAndMoved
     ], function(err) {
       return callback(err, commitId);
     });
@@ -230,14 +279,21 @@ module.exports = function(self, options) {
         return callback(null);
       });
     }
-    function clearSubmitted(callback) {
+    function clearSubmittedAndMoved(callback) {
       return self.apos.docs.db.update({
         _id: from._id
       }, {
         $unset: {
-          workflowSubmitted: 1
+          workflowSubmitted: 1,
+          workflowMovedIsNew: 1
         }
       }, callback);
+    }
+    function move(callback) {
+      if (!from.workflowMovedIsNew) {
+        return callback(null);
+      }
+      return self.repeatMove(req, from, to, callback);
     }
   };
 
@@ -725,6 +781,10 @@ module.exports = function(self, options) {
           }
           var _draft = self.apos.utils.clonePermanent(draft);
           var _live = self.apos.utils.clonePermanent(live);
+          if (_draft.workflowMovedIsNew) {
+            relatedModified.push(draft);
+            return callback(null);            
+          }
           self.deleteExcludedProperties(_draft);
           self.deleteExcludedProperties(_live);
           // Normalize false vs. undefined to prevent false positives
@@ -1667,7 +1727,7 @@ module.exports = function(self, options) {
         from = _.cloneDeep(commit.from);
         to = _.cloneDeep(commit.to);
 
-        return async.series([ getDraft, resolveToSource, applyPatch, resolveToDestination, update ], callback);
+        return async.series([ getDraft, resolveToSource, applyPatch, resolveToDestination, update, move ], callback);
 
         function getDraft(callback) {
           return self.findDocs(req, { workflowGuid: commit.workflowGuid }, locale).toObject(function(err, _draft) {
@@ -1723,8 +1783,17 @@ module.exports = function(self, options) {
           draft.workflowSubmitted = self.getWorkflowSubmittedProperty(req, { type: 'exported' });
           return self.apos.docs.update(req, draft, callback);
         }
+
+        function move(callback) {
+          if (!from.workflowMovedIsNew) {
+            return callback(null);
+          }
+          return self.repeatMove(req, from, draft, callback);
+        }
+
       }, callback);
     }
+
   };
 
   // Force export the doc with the given id to the given locales.
@@ -1835,6 +1904,10 @@ module.exports = function(self, options) {
         function update(callback) {
           success.push(self.liveify(draft.workflowLocale));
           return self.apos.docs.update(req, draft, callback);
+        }
+
+        function move(callback) {
+          return self.repeatMove(req, original, draft, callback);
         }
 
       }, callback);

--- a/lib/api.js
+++ b/lib/api.js
@@ -782,7 +782,7 @@ module.exports = function(self, options) {
           var _live = self.apos.utils.clonePermanent(live);
           if (_draft.workflowMovedIsNew) {
             relatedModified.push(draft);
-            return callback(null);            
+            return callback(null);
           }
           self.deleteExcludedProperties(_draft);
           self.deleteExcludedProperties(_live);

--- a/lib/api.js
+++ b/lib/api.js
@@ -195,7 +195,6 @@ module.exports = function(self, options) {
       });
     }
     function move(callback) {
-      console.log(to._id, targetId, from.workflowMoved.position);
       self.apos.pages.move(req,
         to._id,
         targetId,
@@ -1727,6 +1726,11 @@ module.exports = function(self, options) {
         from = _.cloneDeep(commit.from);
         to = _.cloneDeep(commit.to);
 
+        // Must capture this before it is deleted as it is not a
+        // regular committable property
+
+        const workflowMoved = from.workflowMovedIsNew && from.workflowMoved;
+
         return async.series([ getDraft, resolveToSource, applyPatch, resolveToDestination, update, move ], callback);
 
         function getDraft(callback) {
@@ -1785,10 +1789,10 @@ module.exports = function(self, options) {
         }
 
         function move(callback) {
-          if (!from.workflowMovedIsNew) {
+          if (!workflowMoved) {
             return callback(null);
           }
-          return self.repeatMove(req, from, draft, callback);
+          return self.repeatMove(req, Object.assign(from, { workflowMoved: workflowMoved }), draft, callback);
         }
 
       }, callback);
@@ -1865,7 +1869,7 @@ module.exports = function(self, options) {
         // Our own modifiable copy to safely pass to `resolveToDestination`
         resolvedOriginal = _.cloneDeep(original);
 
-        return async.series([ getDraft, resolveToDestination, applyPatch, update ], callback);
+        return async.series([ getDraft, resolveToDestination, applyPatch, update, move ], callback);
 
         function getDraft(callback) {
           return self.findDocs(req, { workflowGuid: resolvedOriginal.workflowGuid }, locale).toObject(function(err, _draft) {

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -133,7 +133,10 @@ module.exports = function(self, options) {
       'viewGroupsRemovedIds',
       'editUsersRemovedIds',
       'editGroupsRemovedIds',
-      'advisoryLock'
+      'advisoryLock',
+      // Handled separately, as it is an action to carry out
+      // at commit time
+      'workflowMoved'
     ];
 
     // Attachment fields themselves are not directly localized (they are not docs)

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -200,7 +200,7 @@ module.exports = {
       });
     };
 
-    // On the initial invocation of `apos.pages.move`, modify the criteria and filters
+    // On invocation of `apos.pages.move`, modify the criteria and filters
     // to ensure only the relevant locale is in play
 
     var superBeforeMove = self.beforeMove;
@@ -208,9 +208,6 @@ module.exports = {
       return superBeforeMove(req, moved, target, position, options, function(err) {
         if (err) {
           return callback(err);
-        }
-        if (options.workflowRecursing) {
-          return callback(null);
         }
         if (moved.workflowLocale) {
           options.criteria = _.assign({}, options.criteria || {}, { workflowLocale: moved.workflowLocale });
@@ -220,9 +217,11 @@ module.exports = {
       });
     };
 
-    // After a page is moved in one locale, with all of the ripple effects that go with it,
-    // make the same move in all other locales. Note that we already verified we have permissions
-    // across all locales.
+    // After a page is moved in one locale, record the action that
+    // was taken so it can be repeated on a commit or export
+    // without attempting to reconcile differences in where the
+    // destination parent page happens to be at the start
+    // of the operation.
 
     var superAfterMove = self.afterMove;
     self.afterMove = function(req, moved, info, callback) {
@@ -230,54 +229,17 @@ module.exports = {
         if (err) {
           return callback(err);
         }
-        if (info.options.workflowRecursing) {
-          return callback(null);
-        }
-        if (!moved.workflowGuid) {
-          return callback(null);
-        }
-        var locales = {};
-        return async.series([
-          get,
-          invoke
-        ], function(err) {
-          return callback(err);
-        });
-        function get(callback) {
-          // Locate the doc moved and the doc it is moved relative to (target) in all locales other than
-          // the original one
-          var workflow = self.apos.modules['apostrophe-workflow'];
-          return self.apos.docs.db.findWithProjection({ workflowGuid: { $in: [ moved.workflowGuid, info.target.workflowGuid ] }, workflowLocale: { $ne: moved.workflowLocale } }, { workflowGuid: 1, _id: 1, workflowLocale: 1 }).toArray(function(err, docs) {
-            if (err) {
-              return callback(err);
-            }
-            _.each(docs, function(doc) {
-              if (!workflow.locales[doc.workflowLocale]) {
-                // Ignore orphan locales no longer in the configuration, they might
-                // not exist for all of the documents
-                return;
-              }
-              locales[doc.workflowLocale] = locales[doc.workflowLocale] || {};
-              if (doc.workflowGuid === moved.workflowGuid) {
-                locales[doc.workflowLocale].movedId = doc._id;
-              }
-              if (doc.workflowGuid === info.target.workflowGuid) {
-                locales[doc.workflowLocale].targetId = doc._id;
-              }
-            });
-            return callback(null);
-          });
-        }
-        function invoke(callback) {
-          // Reinvoke apos.pages.move
-          return async.eachSeries(_.keys(locales), function(locale, callback) {
-            var _options = _.clone(info.options);
-            _options.criteria = _.assign({}, info.options.criteria || {}, { workflowLocale: locale });
-            _options.filters = _.assign({}, info.options.filters || {}, { workflowLocale: locale });
-            _options.workflowRecursing = true;
-            return self.move(req, locales[locale].movedId, locales[locale].targetId, info.position, _options, callback);
-          }, callback);
-        }
+        return self.apos.docs.db.update({
+          _id: moved._id
+        }, {
+          $set: {
+            workflowMoved: {
+              target: info.target.workflowGuid,
+              position: info.position
+            },
+            workflowMovedIsNew: true
+          }
+        }, callback);
       });
     };
 

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -137,69 +137,6 @@ module.exports = {
       return controls;
     }
 
-    var superMovePermissions = self.movePermissions;
-
-    // "Based on `req`, `moved`, `data.oldParent` and `data.parent`, decide whether
-    // this move should be permitted. If it should not be, report an error." The `apostrophe-pages`
-    // module did this already, but we must consider the impact on all locales.
-
-    self.movePermissions = function(req, moved, data, options, callback) {
-      return superMovePermissions(req, moved, data, options, function(err) {
-        if (err) {
-          return callback(err);
-        }
-        if (!moved.workflowGuid) {
-          // No localization for pages. That's unusual but allowed
-          return callback(null);
-        }
-        // Grab the pages of interest across all locales other than the original (already checked).
-        return self.apos.docs.find(req, {
-          workflowGuid: { $in: [ moved.workflowGuid, data.oldParent.workflowGuid, data.parent.workflowGuid ] },
-          workflowLocale: { $ne: moved.workflowLocale }
-        }).joins(false).areas(false).workflowLocale(null).permission(false).published(null).trash(null).toArray(function(err, pages) {
-          if (err) {
-            return callback(err);
-          }
-          var error = null;
-          var locales = {};
-          _.each(pages, function(page) {
-            var workflow = self.apos.modules['apostrophe-workflow'];
-            if (!workflow.locales[page.workflowLocale]) {
-              // Ignore orphaned locales (no longer in configuration),
-              // do not crash if they are still in the db but not for
-              // newer pages
-              return;
-            }
-            if (!locales[page.workflowLocale]) {
-              locales[page.workflowLocale] = {};
-            }
-            if (page.workflowGuid === moved.workflowGuid) {
-              locales[page.workflowLocale].moved = page;
-            }
-            // Parent does not always change, else statement is not appropriate here
-            if (page.workflowGuid === data.parent.workflowGuid) {
-              locales[page.workflowLocale].parent = page;
-            }
-            if (page.workflowGuid === data.oldParent.workflowGuid) {
-              locales[page.workflowLocale].oldParent = page;
-            }
-          });
-          _.each(locales, function(locale, name) {
-            // Repeat the permissions check for every locale
-            if (!locale.moved._publish) {
-              error = new Error('forbidden');
-              return false;
-            }
-            if ((locale.oldParent._id !== locale.parent._id) && (!locale.parent._edit)) {
-              error = new Error('forbidden');
-              return false;
-            }
-          });
-          return callback(error);
-        });
-      });
-    };
-
     // On invocation of `apos.pages.move`, modify the criteria and filters
     // to ensure only the relevant locale is in play
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "url": "git+https://github.com/punkave/apostrophe-workflow.git"
   },
   "scripts": {
-    "test": "mocha test/test1.js && mocha test/test2.js && mocha test/test3.js && mocha test/testApi.js && eslint ."
+    "test": "mocha && eslint ."
   },
   "version": "2.14.0"
 }

--- a/test/reorganize.js
+++ b/test/reorganize.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var _ = require('@sailshq/lodash');
 var Promise = require('bluebird');
 
 describe('Workflow Reorganize', function() {
@@ -85,7 +84,6 @@ describe('Workflow Reorganize', function() {
     });
   });
 
-
   // it('dump pages', function() {
   //   return apos.docs.db.find({ slug: /^\// }).toArray().then(function(pages) {
   //     console.log(pages);
@@ -154,11 +152,11 @@ describe('Workflow Reorganize', function() {
     let commits;
     const req = apos.tasks.getReq({ locale: 'default-draft' });
     return Promise.try(function() {
-      return workflow.db.find().sort({ createdAt: 1 }).toArray();      
+      return workflow.db.find().sort({ createdAt: 1 }).toArray();
     }).then(function(_commits) {
-      commits = _commits;      return exporter(req, commits[0]._id, [ 'fr' ] );
+      commits = _commits; return exporter(req, commits[0]._id, [ 'fr' ]);
     }).then(function() {
-      return exporter(req, commits[1]._id, [ 'fr' ] );
+      return exporter(req, commits[1]._id, [ 'fr' ]);
     });
   });
 

--- a/test/reorganize.js
+++ b/test/reorganize.js
@@ -84,12 +84,6 @@ describe('Workflow Reorganize', function() {
     });
   });
 
-  // it('dump pages', function() {
-  //   return apos.docs.db.find({ slug: /^\// }).toArray().then(function(pages) {
-  //     console.log(pages);
-  //   });
-  // });
-
   it('page1 and page2 are peers in default-draft locale', function() {
     return page1AndPage2ArePeers('default-draft');
   });
@@ -154,7 +148,8 @@ describe('Workflow Reorganize', function() {
     return Promise.try(function() {
       return workflow.db.find().sort({ createdAt: 1 }).toArray();
     }).then(function(_commits) {
-      commits = _commits; return exporter(req, commits[0]._id, [ 'fr' ]);
+      commits = _commits;
+      return exporter(req, commits[0]._id, [ 'fr' ]);
     }).then(function() {
       return exporter(req, commits[1]._id, [ 'fr' ]);
     });

--- a/test/reorganize.js
+++ b/test/reorganize.js
@@ -1,0 +1,168 @@
+var assert = require('assert');
+var _ = require('@sailshq/lodash');
+var Promise = require('bluebird');
+
+describe('Workflow Core', function() {
+
+  let apos;
+  let page1;
+  let page2;
+
+  this.timeout(20000);
+
+  after(function(done) {
+    require('apostrophe/test-lib/util').destroy(apos, done);
+  });
+
+  /// ///
+  // EXISTENCE
+  /// ///
+
+  it('should be a property of the apos object', function(done) {
+    apos = require('apostrophe')({
+      testModule: true,
+
+      modules: {
+        'apostrophe-pages': {
+          types: [
+            {
+              name: 'home',
+              label: 'Home'
+            },
+            {
+              name: 'testPage',
+              label: 'Test Page'
+            }
+          ]
+        },
+        'apostrophe-workflow': {}
+      },
+      afterInit: function(callback) {
+        assert(apos.modules['apostrophe-workflow']);
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('insert page1 and page2 as peers initially', function() {
+    const req = apos.tasks.getReq({ locale: 'default-draft' });
+    return Promise.try(function() {
+      return apos.pages.find(req, { slug: '/' }).children({ depth: 2 }).toObject();
+    }).then(function(home) {
+      return apos.pages.insert(req, home, {
+        title: 'page1',
+        slug: '/page1',
+        type: 'testPage',
+        published: true,
+        trash: false
+      }).then(function() {
+        return home;
+      });
+    }).then(function(home) {
+      return apos.pages.insert(req, home, {
+        title: 'page2',
+        slug: '/page2',
+        type: 'testPage',
+        published: true,
+        trash: false
+      });
+    });
+  });
+
+
+  // it('dump pages', function() {
+  //   return apos.docs.db.find({ slug: /^\// }).toArray().then(function(pages) {
+  //     console.log(pages);
+  //   });
+  // });
+
+  it('page1 and page2 are peers in default-draft locale', function() {
+    return page1AndPage2ArePeers('default-draft');
+  });
+
+  it('page1 and page2 are peers in default locale', function() {
+    return page1AndPage2ArePeers('default');
+  });
+
+  it('should be able to move page2 under page1 in default-draft', function() {
+    const req = apos.tasks.getReq({ locale: 'default-draft' });
+    return Promise.try(function() {
+      return apos.pages.find(req, { slug: '/' }).children({ depth: 2 }).toObject();
+    }).then(function(home) {
+      const page1 = home._children[0];
+      const page2 = home._children[1];
+      // req, moved, target, relationship
+      return apos.pages.move(req, page2._id, page1._id, 'inside');
+    }).then(function() {
+      return page2IsNestedUnderPage1('default-draft');
+    });
+  });
+
+  it('meanwhile in live locale, page2 should still be a peer', function() {
+    return page1AndPage2ArePeers('default');
+  });
+
+  it('should be able to commit page1', function() {
+    const req = apos.tasks.getReq({ locale: 'default-draft' });
+    const workflow = apos.modules['apostrophe-workflow'];
+    return Promise.try(function() {
+      return apos.pages.find(req, { slug: '/' }).children({ depth: 2 }).toObject();
+    }).then(function(home) {
+      const page1 = home._children[0];
+      return Promise.promisify(workflow.commitLatest)(req, page1._id);
+    });
+  });
+
+  it('should be able to commit page2', function() {
+    const req = apos.tasks.getReq({ locale: 'default-draft' });
+    const workflow = apos.modules['apostrophe-workflow'];
+    return Promise.try(function() {
+      return apos.pages.find(req, { slug: '/' }).children({ depth: 2 }).toObject();
+    }).then(function(home) {
+      const page2 = home._children[0]._children[0];
+      return Promise.promisify(workflow.commitLatest)(req, page2._id);
+    });
+  });
+
+  it('now in live locale page2 should be nested under page1', function() {
+    return page2IsNestedUnderPage1('default');
+  });
+
+  function page1AndPage2ArePeers(locale) {
+    return Promise.try(function() {
+      return apos.docs.db.find({ workflowLocale: locale }).toArray();
+    }).then(function(docs) {
+      return apos.pages.find(apos.tasks.getReq({ locale: locale }), { slug: '/' }).children({ depth: 2, trash: null }).toObject();
+    }).then(function(home) {
+      assert(home);
+      page1 = home._children[0];
+      page2 = home._children[1];
+      assert(page1.title === 'page1');
+      assert(page1.path === '/page1');
+      assert(page1.level === 1);
+      assert(page2.title === 'page2');
+      assert(page2.path === '/page2');
+      assert(page2.level === 1);
+    });
+  }
+
+  function page2IsNestedUnderPage1(locale) {
+    return Promise.try(function() {
+      return apos.pages.find(apos.tasks.getReq({ locale: locale }), { slug: '/' }).children({ depth: 2, trash: null }).toObject();
+    }).then(function(home) {
+      const page1 = home._children[0];
+      assert(page1.title === 'page1');
+      assert(page1.path === '/page1');
+      assert(page1.level === 1);
+      const page2 = page1._children[0];
+      assert(page2.title === 'page2');
+      assert(page2.path === '/page1/page2');
+      assert(page2.level === 2);
+    });
+  }
+
+});

--- a/test/test1.js
+++ b/test/test1.js
@@ -347,24 +347,6 @@ describe('Workflow Core', function() {
 
   });
 
-  it('newly moved page is also in the right place in the other locale', function(done) {
-    // 'Cousin' _id === 4312
-    // 'Parent' _id === 1234
-    apos.pages.find(apos.tasks.getReq({ locale: 'default-draft' }), { path: '/cousin' }).workflowLocale('default').toObject(function(err, page) {
-      if (err) {
-        console.log(err);
-      }
-      assert(!err);
-      // Is the new path correct?
-      assert.equal(page.path, '/cousin');
-      // Is the rank correct?
-      assert.equal(page.rank, 1);
-      // Is the locale filter working?
-      assert.equal(page.workflowLocale, 'default');
-      return done();
-    });
-  });
-
   it('is able to move root/cousin before root/parent/child', function(done) {
     // 'Cousin' _id === 4312
     // 'Child' _id === 2341
@@ -430,20 +412,6 @@ describe('Workflow Core', function() {
       });
     });
 
-  });
-
-  it('moving /parent into /another-parent should also move /parent/sibling in the other locale', function(done) {
-    var cursor = apos.pages.find(apos.tasks.getReq({ locale: 'default-draft' }), { path: '/another-parent/parent/sibling' }).workflowLocale('default');
-    cursor.toObject(function(err, page) {
-      if (err) {
-        console.log(err);
-      }
-      assert(!err);
-      // Is the grandchild's path correct?
-      assert.equal(page.path, '/another-parent/parent/sibling');
-      assert.equal(page.workflowLocale, 'default');
-      return done();
-    });
   });
 
   it('should detect that the home page is an ancestor of any page except itself', function() {

--- a/views/commit-modal.html
+++ b/views/commit-modal.html
@@ -36,6 +36,9 @@
   {% if data.modifiedFields.length %}
     <div class="apos-workflow-modified-fields">
       <p>{{ __('Modified fields: %s', data.modifiedFields | join(', ')) }}</p>
+      {% if data.doc.workflowMovedIsNew %}
+        <p>The page was moved to a new location.</p>
+      {% endif %}
       <p class="apos-workflow-hint">Also see below for content edited in context.</p>
     </div>
   {% endif %}


### PR DESCRIPTION
This feature now works the way you would expect it to. When you move a page, you're moving it for the current draft locale. To push that to the live locale, you commit the page that you moved, and the same move operation is carried out automatically in the live locale (note that the ripple effects on child and peer pages will be the same, if the trees are the same). You can also export a commit that involves a move, or force export a draft which will repeat the most recent move operation on the document in the target locales.

Unit test coverage has been implemented for all three cases, the regression test suite passes, and manual testing has been performed.