### PR TITLE
suppress loader recursion warning for getEditable, which is not part …

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -668,6 +668,13 @@ module.exports = function(self, options) {
     if (!req.user) {
       return res.status(404).send('notfound');
     }
+    // Fetching many related documents with all their joins in turn
+    // is likely to produce some area loader recursion warnings, but
+    // we are not really loading all of these pages to render the
+    // current page, we are just examining what can be committed. 
+    // So suppress the excess warnings because otherwise they could
+    // be very frequent and they don't impact site visitors
+    req.suppressAreaLoaderRecursionWarnings = true;
     var ids = self.apos.launder.ids(req.body.ids);
     return self.getEditable(req, ids, { related: req.body.related }, function(err, modified, unmodified, committable) {
       if (err) {


### PR DESCRIPTION
…of normal page rendering and does not mind if it could miss a distant relative or two