### PR TITLE
use readOnlySession API to prevent more frequently hit web APIs from …

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -665,6 +665,7 @@ module.exports = function(self, options) {
   // live or draft.
 
   self.route('post', 'editable', function(req, res) {
+    self.apos.utils.readOnlySession(req);
     if (!req.user) {
       return res.status(404).send('notfound');
     }
@@ -687,6 +688,7 @@ module.exports = function(self, options) {
   });
 
   self.route('post', 'uncommitted-trash', function(req, res) {
+    self.apos.utils.readOnlySession(req);
     if (!req.user) {
       return res.status(404).send('notfound');
     }
@@ -710,6 +712,7 @@ module.exports = function(self, options) {
   // know we can edit the draft at that point.
 
   self.route('post', 'committable', function(req, res) {
+    self.apos.utils.readOnlySession(req);
     if (!req.user) {
       res.status(404).send('notfound');
     }
@@ -753,6 +756,7 @@ module.exports = function(self, options) {
   // The commit ids returned are the most recent for the related docs in question.
 
   self.route('post', 'related-unexported', function(req, res) {
+    self.apos.utils.readOnlySession(req);
     var id = self.apos.launder.id(req.body.id);
 
     var exportLocales = self.apos.launder.strings(req.body.exportLocales);
@@ -899,6 +903,7 @@ module.exports = function(self, options) {
   // editing privileges for docs of the same type as `id`.
 
   self.route('post', 'editable-locales', function(req, res) {
+    self.apos.utils.readOnlySession(req);
     return self.apos.docs.find(req, { _id: req.body.id }).trash(null).published(null).toObject(function(err, doc) {
       if (err) {
         self.apos.utils.error(err);


### PR DESCRIPTION
…defeating session updates in user-frustrating ways