### PR TITLE
Remove noisy link-to-locale 404 console error

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1203,15 +1203,14 @@ module.exports = function(self, options) {
         self.apos.utils.error(err);
         return res.status(500).send('error');
       }
-      if (doc && doc._url) {
-        // Last step is to use the workflowLocale query parameter to
-        // disambiguate cases where locales have the same URL, which
-        // seems pretty silly but can happen in dev
-        return res.redirect(self.apos.urls.build(doc._url, { workflowLocale: locale }));
-      } else {
-        self.apos.utils.error('link-to-locale: No doc found for slug "' + req.query.slug + '" and locale "' + req.query.locale + '"');
-        return res.status(404).send('not found');
-      }
+      // If no matching document was found, we intentionally redirect
+      // the visitor to the slug they requested, where they will see a
+      // a familiar 404 error
+      var redirectSlug = (doc && doc._url) ? doc._url : slug;
+      // Last step is to use the workflowLocale query parameter to
+      // disambiguate cases where locales have the same URL, which
+      // seems pretty silly but can happen in dev
+      return res.redirect(self.apos.urls.build(redirectSlug, { workflowLocale: locale }));
     });
   });
 


### PR DESCRIPTION
As discussed in #225. This makes it so that when user agents request a document from the link-to-locale route that doesn't exist, we no longer log an error. Instead, we redirect them to the slug they requested on the locale they requested – where they will see a regular 404 page.