### PR TITLE
created a final fallback for the add-missing-locales task that uses a…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -833,6 +833,10 @@ module.exports = function(self, options) {
     var result = [];
     _.each(docs, function(draft) {
       // Also add anything that's joined into the primary doc
+      if (!draft) {
+        self.apos.utils.warn('null doc in getRelated');
+        return;
+      }
       var joins = self.findJoinsInDoc(draft);
       _.each(joins, function(join) {
         if (join.field.type === 'joinByOne') {

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -735,8 +735,8 @@ module.exports = function(self, options) {
     }
 
     return async.series([
-      count,
-      process,
+      // count,
+      // process,
       fallback
     ], callback);
 
@@ -821,21 +821,89 @@ module.exports = function(self, options) {
     }
 
     // There are cases where a suitable ancestor in the tree cannot be found, or a few docs
-    // are missing due to race conditions. To mop these up, we make a final pass based on the
-    // locale with the most docs
+    // are missing due to race conditions. To mop these up, we make a penultimate pass that
+    // considers every unique workflowGuid, preferring the locale with the most docs
+    // as a basis but falling back if necessary to any in which it exists. And in the final
+    // pass, we use an aggregation query to find absolutely every last workflowGuid that
+    // does not have every locale.
 
     function fallback(callback) {
-      return self.apos.migrations.eachDoc({ workflowLocale: basis }, 5, function(doc, callback) {
-        if (!self.includeType(doc.type)) {
-          return setImmediate(callback);
+
+      return async.series([ viaBasis, noBasis ], callback);
+
+      function viaBasis(callback) {
+        return self.apos.migrations.eachDoc({ workflowLocale: basis }, 5, function(doc, callback) {
+          if (!self.includeType(doc.type)) {
+            return setImmediate(callback);
+          }
+          doc.workflowResolveDeferred = true;
+          var afterSaveOptions = _.assign({}, options, {
+            permissions: false,
+            workflowMissingLocalesLive: self.apos.argv.live ? true : 'liveOnly'
+          });
+          return self.docAfterSave(req, doc, afterSaveOptions, callback);
+        }, callback);
+      }
+
+      function noBasis(callback) {
+        var localeNames = Object.keys(self.locales);
+        var orphans;
+        return async.series([ find, fix ], callback); 
+        function find(callback) {
+          const query = [
+            {
+              $match: {
+                workflowLocale: { $in: localeNames }
+              }
+            }, 
+            {
+              $group: {
+                _id: "$workflowGuid",
+                count: { $sum: 1 }
+              },
+            },
+            {
+              $match: {
+                count: { $lt: localeNames.length }
+              }
+            }
+          ];
+
+          return self.apos.docs.db.aggregate(query).toArray(function(err, _orphans) {
+            if (err) {
+              return callback(err);
+            }
+            orphans = _orphans;
+            return callback(null);
+          });
         }
-        doc.workflowResolveDeferred = true;
-        var afterSaveOptions = _.assign({}, options, {
-          permissions: false,
-          workflowMissingLocalesLive: self.apos.argv.live ? true : 'liveOnly'
-        });
-        return self.docAfterSave(req, doc, afterSaveOptions, callback);
-      }, callback);
+
+        function fix(callback) {
+          var seen = {};
+          if (!orphans.length) {
+            return callback(null);
+          }
+          // The aggregation query returns the workflowGuids but I haven't been able to
+          // convince it to give me representative _ids to go with them, so we will just
+          // ignore the additional locales after we fix each one once. -Tom
+          return self.apos.migrations.eachDoc({ workflowGuid: { $in: _.pluck(orphans, '_id') } }, 5, function(doc, callback) {
+            if (seen[doc.workflowGuid]) {
+              return setImmediate(callback);
+            }
+            seen[doc.workflowGuid] = true;
+            if (!self.includeType(doc.type)) {
+              return setImmediate(callback);
+            }
+            doc.workflowResolveDeferred = true;
+            var afterSaveOptions = _.assign({}, options, {
+              permissions: false,
+              workflowMissingLocalesLive: self.apos.argv.live ? true : 'liveOnly'
+            });
+            return self.docAfterSave(req, doc, afterSaveOptions, callback);
+          }, callback);
+        }
+      }
+
     }
 
   };

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -735,8 +735,8 @@ module.exports = function(self, options) {
     }
 
     return async.series([
-      // count,
-      // process,
+      count,
+      process,
       fallback
     ], callback);
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -272,6 +272,9 @@ module.exports = function(self, options) {
     }
 
     function ids(callback) {
+      if (!live) {
+        return callback(null);
+      }
       if (!req.body.resolveRelationshipsToDraft) {
         return callback(null);
       }


### PR DESCRIPTION
… mongo aggregation query to find ALL remaining docs that do not exist in 100% of the expected locales and populate them from an existing locale. Note that all docs must EXIST in every locale (this is a design constraint of the workflow module and not a new decision), although they start as trash if they are not relevant so far for that locale.