### PR TITLE
Fix issues with disabling submittedModal

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -374,9 +374,9 @@ module.exports = function(self, options) {
       self.apos.adminBar.add(self.__meta.name + '-locale-picker-modal', 'Locales');
       items.push(self.__meta.name + '-locale-picker-modal');
     }
-    self.apos.adminBar.add(self.__meta.name + '-manage-modal', 'Submitted');
+    // It's pretty redundant with the new modified documents modal but it's here for bc by default
     if (self.options.submittedModal !== false) {
-      // It's pretty redundant with the new modified documents modal but it's here for bc by default
+      self.apos.adminBar.add(self.__meta.name + '-manage-modal', 'Submitted');
       items.push(self.__meta.name + '-manage-modal');
     }
     self.apos.adminBar.group({


### PR DESCRIPTION
The 2.16.0 release included the new submittedModal option, but when that option is set to `false`, it simply moves the "Submitted" admin bar button out of the "Workflow" dropdown into the main admin bar. This change makes it so that the Submitted button is removed entirely from the admin bar when that option is set to `false`