### PR TITLE
disableExportAfterCommit option (for apostrophe-override-options modu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.17.0
+
+Unit tests passing.
+
+* Added the `disableExportAfterCommit` option, for compatibility with how boolean editable
+fields work in the `apostrophe-override-options` module.
+* Unit test coverage to verify that the new support for adding default values from the schema
+for new fields of the global doc does not break in the presence of workflow.
+
 ## 2.16.2
 
 Unit tests passing.

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ This allows for editors fluent in the other locale to complete any necessary tra
 
 #### If you find this option appears too frequently
 
-Do you export rarely? If so, you may want to set the `exportAfterCommit` option of the `apostrophe-workflow` module to `false`.
+Do you export rarely? If so, you may want to set the `exportAfterCommit` option of the `apostrophe-workflow` module to `false`, or set `disableExportAfterCommit` to `true`. The latter is useful if you are using the `apostrophe-override-options` module to creaqte an editable boolean field for this purpose.
 
 If you do so, the "export" dialog box will not appear right after every commit. Instead the user must choose to access it. The option can be found on the "workflow" dropdown menu, accessed via "Page Settings" or via the editing dialog box for any piece type, including "global."
 

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -364,7 +364,7 @@ module.exports = function(self, options) {
     if (disableExportAfterCommit !== undefined) {
       exportAfterCommit = !disableExportAfterCommit;
     } else {
-      exportAfterCommit = self.getOption(req, 'exportAfterCommit')
+      exportAfterCommit = self.getOption(req, 'exportAfterCommit');
     }
     return {
       action: self.action,

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -356,6 +356,16 @@ module.exports = function(self, options) {
   };
 
   self.getCreateSingletonOptions = function(req) {
+    // disableExportAfterCommit is supported for compatibility with
+    // apostrophe-override-options. If it is not present consider
+    // exportAfterCommit
+    var exportAfterCommit;
+    var disableExportAfterCommit = self.getOption(req, 'disableExportAfterCommit');
+    if (disableExportAfterCommit !== undefined) {
+      exportAfterCommit = !disableExportAfterCommit;
+    } else {
+      exportAfterCommit = self.getOption(req, 'exportAfterCommit')
+    }
     return {
       action: self.action,
       contextGuid: req.data.workflow.context && req.data.workflow.context.workflowGuid,
@@ -364,7 +374,7 @@ module.exports = function(self, options) {
       nestedLocales: self.nestedLocales,
       prefixes: self.prefixes,
       hostnames: self.hostnames,
-      exportAfterCommit: self.getOption(req, 'exportAfterCommit')
+      exportAfterCommit: exportAfterCommit
     };
   };
 

--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "json-diff": "^0.5.3",
     "jsondiffpatch": "^0.2.5",
     "minimatch": "^3.0.4",
-    "qs": "^6.6.0"
+    "qs": "^6.6.0",
+    "request-promise": "^4.2.4"
   },
   "deprecated": false,
   "description": "Workflow, approvals, localization and internationalization for Apostrophe 2.x",
   "devDependencies": {
     "apostrophe": "^2.75.1",
+    "apostrophe-override-options": "^2.2.0",
     "eslint": "^4.15.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.16.0",

--- a/test/lib/modules/apostrophe-pages/views/pages/home.html
+++ b/test/lib/modules/apostrophe-pages/views/pages/home.html
@@ -1,0 +1,2 @@
+{% extends data.outerLayout %}
+<h4>Home Page</h4>

--- a/test/testGlobalDef.js
+++ b/test/testGlobalDef.js
@@ -1,0 +1,136 @@
+var assert = require('assert');
+var apos, apos2;
+var _ = require('@sailshq/lodash');
+
+describe('test global def', function() {
+  this.timeout(5000);
+  after(function(done) {
+    require('apostrophe/test-lib/util').destroy(apos, function() {
+      require('apostrophe/test-lib/util').destroy(apos2, done);
+    });
+  });
+  it('global should exist on the apos object', function(done) {
+    apos = require('apostrophe')({
+      testModule: true,
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7900
+        },
+        'apostrophe-global': {
+          addFields: [
+            {
+              name: 'testString',
+              type: 'string',
+              def: 'populated def'
+            }
+          ]
+        },
+        'apostrophe-workflow': {
+          locales: [
+            {
+              name: 'en',
+              children: [
+                {
+                  name: 'fr'
+                },
+                {
+                  name: 'de'
+                }
+              ]
+            }
+          ],
+          defaultLocale: 'en',
+          alias: 'workflow' // for testing only!
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.global);
+        // In tests this will be the name of the test file,
+        // so override that in order to get apostrophe to
+        // listen normally and not try to run a task. -Tom
+        apos.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('should populate def values of schema properties across locales at insert time', function(done) {
+    return apos.docs.db.find({ slug: 'global' }).toArray(function(err, docs) {
+      assert(!err);
+      assert(docs.length === 6);
+      assert(!_.find(docs, function(doc) {
+        return doc.testString !== 'populated def';
+      }));
+      done();
+    });
+  });
+
+  it('global should exist on the second apos object', function(done) {
+    apos2 = require('apostrophe')({
+      testModule: true,
+      // intentionally the same as previous
+      shortName: 'test',
+      modules: {
+        'apostrophe-express': {
+          secret: 'xxx',
+          port: 7901
+        },
+        'apostrophe-global': {
+          addFields: [
+            {
+              name: 'anotherString',
+              type: 'string',
+              def: 'populated anotherString def'
+            }
+          ]
+        },
+        'apostrophe-workflow': {
+          locales: [
+            {
+              name: 'en',
+              children: [
+                {
+                  name: 'fr'
+                },
+                {
+                  name: 'de'
+                }
+              ]
+            }
+          ],
+          defaultLocale: 'en',
+          alias: 'workflow' // for testing only!
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos2.global);
+        // In tests this will be the name of the test file,
+        // so override that in order to get apostrophe to
+        // listen normally and not try to run a task. -Tom
+        apos2.argv._ = [];
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('should populate def values of schema properties at update time', function(done) {
+    return apos.docs.db.find({ slug: 'global' }).toArray(function(err, docs) {
+      assert(!err);
+      assert(docs.length === 6);
+      assert(!_.find(docs, function(doc) {
+        return (doc.testString !== 'populated def') || (doc.anotherString !== 'populated anotherString def');
+      }));
+      done();
+    });
+  });
+});

--- a/test/testOverrideOptions.js
+++ b/test/testOverrideOptions.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+const request = require('request-promise');
+const _ = require('@sailshq/lodash');
+
+describe('Override Options', function() {
+  this.timeout(5000);
+  let apos;
+
+  after(function(done) {
+    require('apostrophe/test-lib/util').destroy(apos, done);
+  });
+
+  it('should be a property of the apos object', function(done) {
+    apos = require('apostrophe')({
+      testModule: true,
+
+      modules: {
+        'apostrophe-express': {
+          port: 7900
+        },
+        'apostrophe-pages': {
+          park: [],
+          types: [
+            {
+              name: 'home',
+              label: 'Home'
+            },
+            {
+              name: 'testPage',
+              label: 'Test Page'
+            }
+          ]
+        },
+        'apostrophe-workflow': {
+          locales: [
+            {
+              name: 'en',
+              children: [
+                {
+                  name: 'fr'
+                },
+                {
+                  name: 'de'
+                }
+              ]
+            }
+          ],
+          defaultLocale: 'en',
+          alias: 'workflow' // for testing only!
+        },
+        'apostrophe-global': {
+          addFields: [
+            {
+              type: 'boolean',
+              name: 'disableExportAfterCommit',
+              label: 'Disable Export After Commit',
+              def: true
+            }
+          ],
+          overrideOptions: {
+            editable: {
+              'apos.apostrophe-workflow.disableExportAfterCommit': 'disableExportAfterCommit'
+            }
+          }
+        },
+        'apostrophe-override-options': {},
+        // For every request act as if an admin were logged in already
+        'always-admin': {
+          construct: function(self, options) {
+            self.expressMiddleware = function(req, res, next) {
+              const adminReq = self.apos.tasks.getReq();
+              req.user = adminReq.user;
+              return next();
+            };
+          }
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.modules['apostrophe-workflow']);
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('verify disableExportAfterCommit === true for all global docs', function() {
+    return apos.docs.db.find({ type: 'apostrophe-global' }).toArray().then(function(docs) {
+      return (docs.length === 6) && (!_.find(docs, function(doc) { return doc.disableExportAfterCommit !== true; }));
+    });
+  });
+
+  it('verify simulated admin login and on all requests', () => {
+    return request('http://localhost:7900').then((html) => {
+      assert(html.match(/logout/));
+      assert(html.match(/"exportAfterCommit":false/));
+    });
+  });
+
+});

--- a/test/testOverrideOptions.js
+++ b/test/testOverrideOptions.js
@@ -92,7 +92,7 @@ describe('Override Options', function() {
     });
   });
 
-  it('verify simulated admin login and on all requests', () => {
+  it('verify simulated admin login and that "exportAfterCommit":false comes through', () => {
     return request('http://localhost:7900').then((html) => {
       assert(html.match(/logout/));
       assert(html.match(/"exportAfterCommit":false/));

--- a/test/testResolveRelationships.js
+++ b/test/testResolveRelationships.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-describe('Workflow API', function() {
+describe('Resolve Relationships', function() {
   this.timeout(5000);
   var apos;
 


### PR DESCRIPTION
…le which only overrides when true), and unit tests to verify the new def support for global docs does not break with workflow