### PR TITLE
moved all database operations at startup into apostrophe:migrate even…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var async = require('async');
+var Promise = require('bluebird');
 
 var modules = [
   'apostrophe-workflow-areas',
@@ -77,10 +78,12 @@ module.exports = {
     self.composeApiCalls();
     self.addWorkflowModifiedMigration();
     self.addWorkflowLastCommittedMigration();
+    self.on('apostrophe-pages:beforeParkAll', 'updateHistoricalPrefixesPromisified', function() {
+      return Promise.promisify(self.updateHistoricalPrefixes)();
+    });
     return async.series([
       self.enableCollection,
-      self.enableFacts,
-      self.updateHistoricalPrefixes
+      self.enableFacts
     ], callback);
   },
 

--- a/test/test3.js
+++ b/test/test3.js
@@ -214,7 +214,7 @@ describe('Workflow Add Missing Locales Inheritance And Prefix Changes', function
       var usEn = _.find(docs, { workflowLocale: 'us-en' });
       assert(usEn);
       assert(usEn.origin === 'us');
-      assert(usEn.slug === '/us-en/test');
+      assert.equal(usEn.slug, '/us-en/test');
       var usFr = _.find(docs, { workflowLocale: 'us-fr' });
       assert(usFr);
       assert(usFr.origin === 'us');
@@ -309,7 +309,7 @@ describe('Workflow Add Missing Locales Inheritance And Prefix Changes', function
       var usEn = _.find(docs, { workflowLocale: 'us-en' });
       assert(usEn);
       assert(usEn.origin === 'us');
-      assert(usEn.slug === '/us-en/test');
+      assert.equal(usEn.slug, '/us-en/test');
       var usFr = _.find(docs, { workflowLocale: 'us-fr' });
       assert(usFr);
       assert(usFr.origin === 'us');
@@ -393,7 +393,7 @@ describe('Workflow Add Missing Locales Inheritance And Prefix Changes', function
       var usEn = _.find(docs, { workflowLocale: 'us-en' });
       assert(usEn);
       assert(usEn.origin === 'us');
-      assert(usEn.slug === '/test');
+      assert.equal(usEn.slug, '/test');
       var usFr = _.find(docs, { workflowLocale: 'us-fr' });
       assert(usFr);
       assert(usFr.origin === 'us');


### PR DESCRIPTION
…t handlers. This event is emitted right after modules run their afterInit handlers, or not at all if APOS_NO_MIGRATE or the global migrate option is set to false. In addition, dev asset generation and traditional named one-time migrations now run on this event. apostrophe-migrations:migrate thus becomes the one and only task that does startup db operations if you set APOS_NO_MIGRATE, which is helpful to enterprise clients with very large numbers of long distance replicating nodes in their mongodb configuration. One exception: we still do a query for distinct content types in the db for stability and reliability reasons. This is an indexed query on an index with a small number of values so it should not take any appreciable time and removing it could pose more stability risks than it is worth. We should test at this point.