### PR TITLE
apostrophe-workflow:dereplicate task, for migration to `replicateAcrossLocales: false`

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -366,29 +366,53 @@ module.exports = function(self, options) {
       {
         $match: {
           workflowLocale: { $exists: 1 },
-          trash: false
+          trash: {
+            $ne: true
+          }
         }
       },
       {
         $group: {
           _id: "$workflowGuid",
-          count: { $sum: 1 }
+          count: { $sum: 1 },
+          workflowLocales: { $push: "$workflowLocale" }
         }
       },
       {
         $match: {
-          count: { $eq: 2 }
+          count: {
+            // Either it's valid in draft and trash in live for its original locale
+            // or it's valid in both for its original locale. If it is trash in
+            // every locale it doesn't fit the profile and we should leave it alone
+            $gte: 1,
+            $lte: 2
+          }
         }
       }
     ]).toArray().then(function(orphans) {
-      var seen = {};
       if (!orphans.length) {
         return;
       }
-      return self.apos.migrations.remove({
-        workflowGuid: { $in: _.pluck(orphans, '_id') },
-        trash: true
+      var bulk = self.apos.docs.db.initializeUnorderedBulkOp();
+      var count = 0;
+      orphans.forEach(function(orphan) {
+        var c = bulk.find({
+          workflowGuid: orphan._id,
+          workflowLocale: {
+            $nin: [
+              self.draftify(orphan.workflowLocales[0]),
+              self.liveify(orphan.workflowLocales[0])
+            ]
+          }
+        });
+        c.remove();
+        count++;
       });
+      if (!count) {
+        // bulk.execute will throw an error if there are no updates
+        return;
+      }
+      return bulk.execute();
     });
   };
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -361,8 +361,43 @@ module.exports = function(self, options) {
     }
   };
 
+  self.dereplicateTask = function() {
+    return self.apos.docs.db.aggregate([
+      {
+        $match: {
+          workflowLocale: { $exists: 1 },
+          trash: false
+        }
+      },
+      {
+        $group: {
+          _id: "$workflowGuid",
+          count: { $sum: 1 }
+        }
+      },
+      {
+        $match: {
+          count: { $eq: 2 }
+        }
+      }
+    ]).toArray().then(function(orphans) {
+      var seen = {};
+      if (!orphans.length) {
+        return;
+      }
+      return self.apos.migrations.remove({
+        workflowGuid: { $in: _.pluck(orphans, '_id') },
+        trash: true
+      });
+    });
+  };
+
   self.addTask('recompute-modified', 'Recompute the workflowModified flag for every doc. Not needed unless you have\nperformed modifications directly with the MongoDB APIs, bypassing Apostrophe,\nand you need workflow to see those modifications as changes. In future, consider\nsetting workflowModified to true via your own code rather than relying on this\ntime-consuming task.', function(apos, argv) {
     return self.recomputeModified();
+  });
+
+  self.addTask('dereplicate', 'Dereplicate docs. Used when transitioning to the "replicateAcrossLocales: false"\noption, which should be turned on before running this task. This task looks for docs\nthat are in the trash in all but two locales (live and draft of the\nsame user-facing locale), and removes them from the locales where they\nare in the trash. THIS DELETES CONTENT FROM THE DATABASE.', function(apos, argv) {
+    return self.dereplicateTask();
   });
 
 };

--- a/test/testDereplicate.js
+++ b/test/testDereplicate.js
@@ -1,0 +1,135 @@
+let assert = require('assert');
+let _ = require('@sailshq/lodash');
+
+describe('Workflow dereplicate task', function() {
+
+  let apos;
+
+  this.timeout(20000);
+
+  after(function(done) {
+    require('apostrophe/test-lib/util').destroy(apos, done);
+  });
+
+  /// ///
+  // EXISTENCE
+  /// ///
+
+  it('should be a property of the apos object', function(done) {
+    apos = require('apostrophe')({
+      testModule: true,
+
+      modules: {
+        'apostrophe-pages': {
+          park: [],
+          types: [
+            {
+              name: 'home',
+              label: 'Home'
+            },
+            {
+              name: 'testPage',
+              label: 'Test Page'
+            }
+          ]
+        },
+        'products': {},
+        'apostrophe-workflow': {
+          alias: 'workflow',
+          locales: [
+            {
+              name: 'default',
+              label: 'Default',
+              private: true,
+              children: [
+                {
+                  name: 'fr'
+                },
+                {
+                  name: 'us'
+                },
+                {
+                  name: 'es'
+                }
+              ]
+            }
+          ]
+          // Do replicate, to create the test case
+        }
+      },
+      afterInit: function(callback) {
+        assert(apos.workflow);
+        return callback(null);
+      },
+      afterListen: function(err) {
+        assert(!err);
+        done();
+      }
+    });
+  });
+
+  it('newly inserted subpage gets replicated initially', function() {
+    // Use a child locale so it is trash in all other locales at first
+    let req = apos.tasks.getReq({ locale: 'es-draft' });
+    return apos.pages.find(req, { slug: '/' }).toObject().then(function(home) {
+      assert(home);
+      return apos.pages.insert(req, home._id, { title: 'About', slug: '/about', type: 'testPage', published: true });
+    }).then(function(subpage) {
+      assert(subpage);
+      assert(subpage.slug === '/about');
+      assert(subpage.workflowGuid);
+      return apos.docs.db.find({ workflowGuid: subpage.workflowGuid }).toArray();
+    }).then(function(peers) {
+      assert(peers.length === 8);
+    });
+  });
+
+  it('run dereplication task without crashing', function() {
+    return apos.tasks.invoke('apostrophe-workflow:dereplicate', [], {});
+  });
+
+  it('dump slugs', function() {
+    return apos.docs.db.find({}, { slug: 1, workflowLocale: 1, workflowGuid: 1, trash: true }).toArray().then(function(docs) {
+    });
+  });
+
+  it('newly inserted subpage is no longer replicated to extra locales', function() {
+    return apos.docs.db.findOne({ slug: '/about' }).then(function(subpage) {
+      assert(subpage);
+      assert(subpage.slug === '/about');
+      assert(subpage.workflowGuid);
+      return apos.docs.db.find({ workflowGuid: subpage.workflowGuid }).toArray();
+    }).then(function(peers) {
+      assert.equal(peers.length, 2);
+      assert(peers.find(function(peer) {
+        return peer.workflowLocale === 'es';
+      }));
+      assert(peers.find(function(peer) {
+        return peer.workflowLocale === 'es-draft';
+      }));
+    });
+  });
+
+  it('home page should still be replicated', function() {
+    return apos.docs.db.find({ level: 0, slug: '/' }).toArray().then(function(homes) {
+      assert(homes);
+      assert(homes.length === 8);
+      const homeLocales = _.pluck(homes, 'workflowLocale');
+      assert(!Object.keys(apos.workflow.locales).find(function(locale) {
+        return (!(homeLocales.indexOf(locale) !== -1));
+      }));
+    });
+  });
+
+  it('global doc page should still be replicated', function() {
+    return apos.docs.db.find({ type: 'apostrophe-global' }).toArray().then(function(globals) {
+      assert(globals);
+      assert(globals.length === 8);
+      const globalLocales = _.pluck(globals, 'workflowLocale');
+      assert(!Object.keys(apos.workflow.locales).find(function(locale) {
+        return (!(globalLocales.indexOf(locale) !== -1));
+      }));
+    });
+  });
+
+});

--- a/test/testDereplicate.js
+++ b/test/testDereplicate.js
@@ -88,11 +88,6 @@ describe('Workflow dereplicate task', function() {
     return apos.tasks.invoke('apostrophe-workflow:dereplicate', [], {});
   });
 
-  it('dump slugs', function() {
-    return apos.docs.db.find({}, { slug: 1, workflowLocale: 1, workflowGuid: 1, trash: true }).toArray().then(function(docs) {
-    });
-  });
-
   it('newly inserted subpage is no longer replicated to extra locales', function() {
     return apos.docs.db.findOne({ slug: '/about' }).then(function(subpage) {
       assert(subpage);


### PR DESCRIPTION
The option, which we published last week, prevents Apostrophe Workflow from copying every document to every locale automatically at creation time. The problem is that for those who are already using Workflow, there are already tons of documents that are "only really meant for one locale" but have been replicated already.

This task cleans up that situation. It is not a migration because it makes a subjective call, although it is perfect for most people migrating to this option. Edge cases like "I really truly want this to exist in other locales even though it's trash in all but one and I would be cheesed about having to export it later" are rare, we just need users to know that's what they are opting into.

The algorithm is this:

"If a document is trash in all locales but one, remove it entirely from the extra locales. Otherwise leave it alone." Existing as draft, live or both outside of the trash in just one locale (one language...) is sufficient to trigger this.

We use an aggregation query to find the candidates and we use a mongodb bulk operation to carry out the cleanup, taking care not to delete either the draft or live doc for the locale we're keeping, even if one of them is in the trash (for instance: not yet committed, but under work as a draft).