### PR TITLE
Check 'exportAfterCommit' after batchCommit.

### DIFF
--- a/lib/modules/apostrophe-workflow-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-workflow-pieces/public/js/manager-modal.js
@@ -18,7 +18,10 @@ apos.define('apostrophe-pieces-manager-modal', {
         "Are you sure you want to commit " + self.choices.length + " item(s)?",
         {
           success: function(results, callback) {
-            return workflow.batchExport(_.values(results), callback);
+          	if ((workflow.options.exportAfterCommit !== false)){
+          		return workflow.batchExport(_.values(results), callback);
+          	}
+          	return callback(null);            
           }
         }
       );


### PR DESCRIPTION
`exportAfterCommit` option is checked after commiting a piece but not when doing a batch commit. 