### PR TITLE
Add preview mode for users

### DIFF
--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -328,8 +328,8 @@ module.exports = function(self, options) {
     // Also adds a class on <body> for both workflow modes
     if (req.user) {
       var workflowMode = req.session.workflowMode;
-      req.data.isPreview = req.session.isPreview;
-      if (workflowMode === 'live' || req.session.isPreview) {
+      req.data.workflowPreview = req.session.workflowPreview;
+      if (workflowMode === 'live' || req.session.workflowPreview) {
         req.disableEditing = true;
       }
       self.apos.templates.addBodyClass(req, 'apos-workflow-' + workflowMode + '-page');

--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -328,7 +328,8 @@ module.exports = function(self, options) {
     // Also adds a class on <body> for both workflow modes
     if (req.user) {
       var workflowMode = req.session.workflowMode;
-      if (workflowMode === 'live') {
+      req.data.isPreview = req.session.isPreview;
+      if (workflowMode === 'live' || req.session.isPreview) {
         req.disableEditing = true;
       }
       self.apos.templates.addBodyClass(req, 'apos-workflow-' + workflowMode + '-page');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -222,14 +222,14 @@ module.exports = function(self, options) {
       req.session.workflowMode = (req.body.mode === 'draft' || req.body.mode === 'preview') ? 'draft' : 'live';
       if (req.body.mode === 'preview') {
         req.body.mode = 'draft';
-        req.session.isPreview = true;
+        req.session.workflowPreview = true;
         req.locale = self.draftify(req.locale);
       } else if (req.body.mode === 'draft') {
         req.locale = self.draftify(req.locale);
-        req.session.isPreview = false;
+        req.session.workflowPreview = false;
       } else {
         req.locale = self.liveify(req.locale);
-        req.session.isPreview = false;
+        req.session.workflowPreview = false;
       }
       return self.apos.docs.find(req, { workflowGuid: self.apos.launder.id(req.body.workflowGuid) })
         .published(null)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -219,11 +219,17 @@ module.exports = function(self, options) {
         // Confusion to the enemy
         return res.status(404).send('not found');
       }
-      req.session.workflowMode = (req.body.mode === 'draft') ? 'draft' : 'live';
-      if (req.body.mode === 'draft') {
+      req.session.workflowMode = (req.body.mode === 'draft' || req.body.mode === 'preview') ? 'draft' : 'live';
+      if (req.body.mode === 'preview') {
+        req.body.mode = 'draft';
+        req.session.isPreview = true;
         req.locale = self.draftify(req.locale);
+      } else if (req.body.mode === 'draft') {
+        req.locale = self.draftify(req.locale);
+        req.session.isPreview = false;
       } else {
         req.locale = self.liveify(req.locale);
+        req.session.isPreview = false;
       }
       return self.apos.docs.find(req, { workflowGuid: self.apos.launder.id(req.body.workflowGuid) })
         .published(null)

--- a/views/menu.html
+++ b/views/menu.html
@@ -1,5 +1,10 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 
+{%- set workflowMode = data.workflowMode -%}
+{% if data.isPreview %}
+  {%- set workflowMode = 'preview' -%}
+{% endif %}
+
 <div class="apos-workflow-menu" data-apos-workflow-menu>
   {% if data.localized %}
   	{{ buttons.normal('Locale: ' + data.workflow.locale, { action: 'admin-bar-item', value: 'apostrophe-workflow-locale-picker-modal' }, 'apos-workflow-locale-button' ) }}
@@ -7,13 +12,18 @@
 
 	<div class="apos-dropdown apos-dropdown--button apos-dropdown--up apos-workflow-state" data-apos-dropdown="up" data-apos-actionable="">
 		<a class="apos-button apos-workflow-state-toggle" data-apos-dropdown-button-label="" style="padding-right: 20px;">
-			<span class="apos-button-label">Mode: {{ data.workflowMode | capitalize }}</span>
+			<span class="apos-button-label">Mode: {{ workflowMode | capitalize }}</span>
 		</a>
 		<ul class="apos-dropdown-items" data-apos-dropdown-items="">
-			{% if data.workflowMode == 'draft' %}
+      {% if data.isPreview %}
+        <li class="apos-dropdown-item" data-apos-workflow-mode="live">Live</li>
+        <li class="apos-dropdown-item" data-apos-workflow-mode="draft">Draft</li>
+			{% elseif data.workflowMode == 'draft' %}
 				<li class="apos-dropdown-item" data-apos-workflow-mode="live">Live</li>
+        <li class="apos-dropdown-item" data-apos-workflow-mode="preview">Preview</li>
 			{% else %}
 				<li class="apos-dropdown-item" data-apos-workflow-mode="draft">Draft</li>
+        <li class="apos-dropdown-item" data-apos-workflow-mode="preview">Preview</li>
 			{% endif %}
 		</ul>
   </div>

--- a/views/menu.html
+++ b/views/menu.html
@@ -15,10 +15,10 @@
 			<span class="apos-button-label">Mode: {{ workflowMode | capitalize }}</span>
 		</a>
 		<ul class="apos-dropdown-items" data-apos-dropdown-items="">
-      {% if data.isPreview %}
+      {% if workflowMode == 'preview' %}
         <li class="apos-dropdown-item" data-apos-workflow-mode="live">Live</li>
         <li class="apos-dropdown-item" data-apos-workflow-mode="draft">Draft</li>
-			{% elseif data.workflowMode == 'draft' %}
+			{% elseif workflowMode == 'draft' %}
 				<li class="apos-dropdown-item" data-apos-workflow-mode="live">Live</li>
         <li class="apos-dropdown-item" data-apos-workflow-mode="preview">Preview</li>
 			{% else %}

--- a/views/menu.html
+++ b/views/menu.html
@@ -1,7 +1,7 @@
 {%- import 'apostrophe-ui:components/buttons.html' as buttons -%}
 
 {%- set workflowMode = data.workflowMode -%}
-{% if data.isPreview %}
+{% if data.workflowPreview %}
   {%- set workflowMode = 'preview' -%}
 {% endif %}
 


### PR DESCRIPTION
_Description_: Apostrophe currently has two workflow modes to view the docs

- Draft
- Live

The Permission model we(in our organisation) follow does't allow everybody to commit the changes to live mode. Only a few people has access to commit the pages while the others only has access to edit the content of the page. The following scenario explains the issue we are facing

- Lets say a user has edit access (lets call him **user 1**). He has edited the page but he has not viewed or cannot see how the page is going to look in live mode without all the "apos-ui" editor controls, without explicitly committing the page.
- This means a user with appropriate permissions (**user 2**) has to commit the page, every time
**user 1** wishes to see the widget or template he's working without "apos-ui" editor controls. This creates a dependency and delays the process.

_Solution_:
This implementation adds a separate option in modes called "**Preview**". The current apostrophe architecture maintains a separate record for **draft** and **live** versions in DB. But here in this case we don't have to maintain a separate record, since preview mode is essentially the **draft** mode document shown to users without all those "**apos-ui**" editor controls. So i have introduced a flag called "**isPreview**" in the session object to identify if the preview mode has been selected and i am disabling the editor controls conditionally.

So in the future even if we are going ahead with a multi-mode architecture, we might want to handle the preview mode this way to save DB space and reduce complexity of implementation.
