### PR TITLE
fixed permissions issues around the "manage workflow" modal

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,6 +19,9 @@ module.exports = function(self, options) {
           return self.locales[locale].lang;
         }
         return locale.replace(/[-_]\w+$/, '');
+      },
+      committable: function(draft) {
+        return self.filterCommittableDrafts(self.apos.templates.contextReq, [ draft ]).length > 0;
       }
     });
   };

--- a/lib/modules/apostrophe-workflow-modified-documents/index.js
+++ b/lib/modules/apostrophe-workflow-modified-documents/index.js
@@ -115,5 +115,16 @@ module.exports = {
         group.items.push(self.__meta.name);
       }
     };
+    // Since this is an overview of many doc types, all that is required
+    // is that you be able to potentially edit at least one doc type that
+    // is subject to workflow
+    self.requireEditor = function(req, res, next) {
+      if (!_.find(Object.keys(self.apos.docs.managers), function(name) {
+        return self.apos.modules['apostrophe-workflow'].includeType(name) && self.apos.permissions.can(req, 'edit-' + name);
+      })) {
+        return self.apiResponse(res, 'forbidden');
+      }
+      return next();
+    };
   }
 };

--- a/lib/modules/apostrophe-workflow-modified-documents/views/manageListPage.html
+++ b/lib/modules/apostrophe-workflow-modified-documents/views/manageListPage.html
@@ -12,13 +12,17 @@
     <td>{% if piece.workflowSubmitted %}{{ __('Yes') }}{% else %}{{ __('No') }}{% endif %}</td>
     <td>{{ piece.workflowLastCommitted.at | date('YYYY-MM-DD') }}<br />{{ piece.workflowLastCommitted.user.title }}</td>
     <td>
-      {% if apos.utils.beginsWith(piece.slug, '/') %}
-        <a href="{{ piece._url }}">{{ __('Edit') }}</a>
-      {% else %}
-        <a href="#" data-apos-edit-{{ piece.type }}="{{ piece._id }}">{{ __('Edit') }}</a>
+      {% if piece._edit %}
+        {% if apos.utils.beginsWith(piece.slug, '/') %}
+          <a href="{{ piece._url }}">{{ __('Edit') }}</a>
+        {% else %}
+          <a href="#" data-apos-edit-{{ piece.type }}="{{ piece._id }}">{{ __('Edit') }}</a>
+        {% endif %}
+        {% if apos.modules['apostrophe-workflow'].committable(piece) %}
+          <a href="#" data-apos-workflow-commit="{{ piece._id }}">{{ __('Commit') }}</a>
+          <a href="#" data-apos-workflow-revert-to-live="{{ piece._id }}">{{ __('Revert') }}</a>
+        {% endif %}
       {% endif %}
-      <a href="#" data-apos-workflow-commit="{{ piece._id }}">{{ __('Commit') }}</a>
-      <a href="#" data-apos-workflow-revert-to-live="{{ piece._id }}">{{ __('Revert') }}</a>
     </td>
   </tr>
 {% endfor %}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -543,7 +543,7 @@ module.exports = function(self, options) {
       ], function(err) {
         if (err) {
           self.apos.utils.error(err);
-          res.status(500).send('error');
+          return res.status(500).send('error');
         }
         var preview;
         var module = self.apos.docs.getManager(draft.type);
@@ -567,6 +567,9 @@ module.exports = function(self, options) {
         return self.getDraftAndLive(req, id, {}, function(err, _draft, _live) {
           draft = _draft;
           live = _live;
+          if (!(draft && live)) {
+            return res.status(404).send('notfound');
+          }
           return callback(err);
         });
       }


### PR DESCRIPTION
In #254 it was pointed out that the "manage workflow" modal can actually lead to a crash when an inappropriate user tries to use the "commit" buttons that should not be there, in their case.

Also the test for whether that modal is accessible at all needed a rethink for permissions.

In general workflow has thorough permissions support but this recently added modal, created in an era when some of our enterprise clients use permissions surprisingly little, had some loose ends.