### PR TITLE
256 allow mere editors to see submit button

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -504,7 +504,7 @@ module.exports = function(self, options) {
         criteria
       ]
     };
-    return self.apos.docs.find(req, criteria, self.getSubmittedProjection()).sort({ 'workflowSubmitted.when': -1 }).trash(null).published(null).toArray(callback);
+    return self.apos.docs.find(req, criteria, self.getSubmittedProjection()).sort({ 'workflowSubmitted.when': -1 }).trash(null).published(null).permission('edit').toArray(callback);
   };
 
   // Given an array of draft docs, returns an array containing only those
@@ -738,8 +738,6 @@ module.exports = function(self, options) {
 
     var related = [];
 
-    var toLive = {};
-
     var relatedModified;
     var relatedUnmodified;
     var committable;
@@ -758,16 +756,15 @@ module.exports = function(self, options) {
     function getKnown(callback) {
       related = [];
       return async.eachSeries(ids, function(id, callback) {
-        return self.getDraftAndLive(req, id, {}, function(err, draft, live) {
+        return self.findDocs(req, { _id: id }).areas(true).joins(true).toObject(function(err, draft) {
           if (err) {
-            if (err === 'notfound') {
-              // Just skip it
-              return callback(null);
-            }
             return callback(err);
           }
+          if (!draft) {
+            // Just not allowed to access this one probably, skip it
+            return callback(null);
+          }
           related.push(draft);
-          toLive[draft.workflowGuid] = live;
           return callback(null);
         });
       }, callback);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,6 +19,9 @@ module.exports = function(self, options) {
           return self.locales[locale].lang;
         }
         return locale.replace(/[-_]\w+$/, '');
+      },
+      committable: function(draft) {
+        return self.filterCommittableDrafts(self.apos.templates.contextReq, [ draft ]).length > 0;
       }
     });
   };

--- a/lib/modules/apostrophe-workflow-modified-documents/index.js
+++ b/lib/modules/apostrophe-workflow-modified-documents/index.js
@@ -115,5 +115,16 @@ module.exports = {
         group.items.push(self.__meta.name);
       }
     };
+    // Since this is an overview of many doc types, all that is required
+    // is that you be able to potentially edit at least one doc type that
+    // is subject to workflow
+    self.requireEditor = function(req, res, next) {
+      if (!_.find(Object.keys(self.apos.docs.managers), function(name) {
+        return self.apos.modules['apostrophe-workflow'].includeType(name) && self.apos.permissions.can(req, 'edit-' + name);
+      })) {
+        return self.apiResponse(res, 'forbidden');
+      }
+      return next();
+    };
   }
 };

--- a/lib/modules/apostrophe-workflow-modified-documents/views/manageListPage.html
+++ b/lib/modules/apostrophe-workflow-modified-documents/views/manageListPage.html
@@ -12,13 +12,17 @@
     <td>{% if piece.workflowSubmitted %}{{ __('Yes') }}{% else %}{{ __('No') }}{% endif %}</td>
     <td>{{ piece.workflowLastCommitted.at | date('YYYY-MM-DD') }}<br />{{ piece.workflowLastCommitted.user.title }}</td>
     <td>
-      {% if apos.utils.beginsWith(piece.slug, '/') %}
-        <a href="{{ piece._url }}">{{ __('Edit') }}</a>
-      {% else %}
-        <a href="#" data-apos-edit-{{ piece.type }}="{{ piece._id }}">{{ __('Edit') }}</a>
+      {% if piece._edit %}
+        {% if apos.utils.beginsWith(piece.slug, '/') %}
+          <a href="{{ piece._url }}">{{ __('Edit') }}</a>
+        {% else %}
+          <a href="#" data-apos-edit-{{ piece.type }}="{{ piece._id }}">{{ __('Edit') }}</a>
+        {% endif %}
+        {% if apos.modules['apostrophe-workflow'].committable(piece) %}
+          <a href="#" data-apos-workflow-commit="{{ piece._id }}">{{ __('Commit') }}</a>
+          <a href="#" data-apos-workflow-revert-to-live="{{ piece._id }}">{{ __('Revert') }}</a>
+        {% endif %}
       {% endif %}
-      <a href="#" data-apos-workflow-commit="{{ piece._id }}">{{ __('Commit') }}</a>
-      <a href="#" data-apos-workflow-revert-to-live="{{ piece._id }}">{{ __('Revert') }}</a>
     </td>
   </tr>
 {% endfor %}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -543,7 +543,7 @@ module.exports = function(self, options) {
       ], function(err) {
         if (err) {
           self.apos.utils.error(err);
-          res.status(500).send('error');
+          return res.status(500).send('error');
         }
         var preview;
         var module = self.apos.docs.getManager(draft.type);
@@ -567,6 +567,9 @@ module.exports = function(self, options) {
         return self.getDraftAndLive(req, id, {}, function(err, _draft, _live) {
           draft = _draft;
           live = _live;
+          if (!(draft && live)) {
+            return res.status(404).send('notfound');
+          }
           return callback(err);
         });
       }


### PR DESCRIPTION
Fix for #256:

* A mere editor (someone who can edit but not commit) can now properly see the "submit" button after they make the change.
* In addition, they will only see documents they can actually edit in the "Submitted" modal. That modal is not commonly used now that the "Manage Workflow" view is available, but it should still be appropriately robust in this area.