### PR TITLE
Hotfix/0.5 all new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 node_modules
 # We do not commit CSS, only LESS
 public/css/*.css
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-var _ = require('lodash');
-var async = require('async');
-var moment = require('moment');
-
 module.exports = workflow;
 
 function workflow(options, callback) {
@@ -41,7 +37,7 @@ workflow.Construct = function(options, callback) {
 
   self._app.get(options.loadUrl || self._action + '/load', function(req, res) {
     var criteria = {
-      submitDraft: { $exists: 1 },
+      submitDraft: { $exists: 1 }
     };
     if (self._apos.options.workflow && self._apos.options.workflow.forPublishers) {
       criteria.draftAuthoredById = { $ne: req.user._id };
@@ -87,4 +83,3 @@ workflow.Construct = function(options, callback) {
     process.nextTick(function() { return callback(null); });
   }
 };
-

--- a/package.json
+++ b/package.json
@@ -23,10 +23,5 @@
   "bugs": {
     "url": "https://github.com/apostrophecms/apostrophe-workflow/issues"
   },
-  "homepage": "https://github.com/apostrophecms/apostrophe-workflow",
-  "dependencies": {
-    "async": "^0.9.0",
-    "lodash": "^2.4.1",
-    "moment": "^2.8.1"
-  }
+  "homepage": "https://github.com/apostrophecms/apostrophe-workflow"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-workflow",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Provides optional approval workflow for the Apostrophe CMS. For most projects this is overkill.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/punkave/apostrophe-workflow"
+    "url": "https://github.com/apostrophecms/apostrophe-workflow"
   },
   "keywords": [
     "workflow",
@@ -21,9 +21,9 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/punkave/apostrophe-workflow/issues"
+    "url": "https://github.com/apostrophecms/apostrophe-workflow/issues"
   },
-  "homepage": "https://github.com/punkave/apostrophe-workflow",
+  "homepage": "https://github.com/apostrophecms/apostrophe-workflow",
   "dependencies": {
     "async": "^0.9.0",
     "lodash": "^2.4.1",

--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -143,7 +143,7 @@ function AposWorkflowManager() {
       // we can add new subpages but that's really about it. Don't
       // let mere editors do things for which we don't have
       // a workflow UI
-      $('[data-new-page]').siblings().remove();
+      $('.apos-page-bar [class*="apos-new"]').siblings().remove();
     }
     if (document.location.href.match(/\?workflowEditMode/)) {
       $('[data-workflow-mode="draft"]').click();


### PR DESCRIPTION
Previously the client JS removed siblings of the "New Page" button, but that missed any snippet types that aren't pages. The update makes this broader to capture those types.