### PR TITLE
Fix issue with Commit Button after Reorganizing Pages

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -853,8 +853,13 @@ module.exports = function(self, options) {
       if (err) {
         return callback(err);
       }
+
+      // If workflowMovedIsNew is set on the draft doc it means a couple of things
+      // 1) Page has been moved from one folder to another or within the same folder.
+      // 2) There are changes to be committed. Commit flow removes workflowMovedIsNew flag.
+      // So return false so that a commit button is shown on the page.
       if (_draft.workflowMovedIsNew) {
-        return callback(null, true);
+        return callback(null, false);
       }
       self.deleteExcludedProperties(_draft);
       self.deleteExcludedProperties(_live);


### PR DESCRIPTION
Steps to Reproduce and more details about the Bug

https://www.notion.so/Commit-Button-Not-Visible-After-Reorganising-Pages-7e6f795406da42d1bcceb651140ae6af