### PR TITLE
"Batch force export" now also supports force-exporting related documents at the same time

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -948,6 +948,17 @@ module.exports = function(self, options) {
         }
       });
     });
+    // Discard null docs and duplicates
+    result = _.filter(result, function(resultOne) {
+      return !!resultOne;
+    });
+    var seen = {};
+    result = _.filter(result, function(resultOne) {
+      if (!seen[resultOne._id]) {
+        seen[resultOne._id] = true;
+        return true;
+      }
+    });
     return callback(null, result);
     function mapToItems(values) {
       return _.map(values, function(value) {

--- a/lib/modules/apostrophe-workflow-templates/index.js
+++ b/lib/modules/apostrophe-workflow-templates/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var _ = require('@sailshq/lodash');
 
 module.exports = {
   improve: 'apostrophe-templates',

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -117,13 +117,82 @@ module.exports = function(self, options) {
     });
 
     self.route('post', 'batch-force-export', self.sortPageIds, function(req, res) {
-      return self.apos.modules['apostrophe-jobs'].run(req, function(req, id, callback) {
-        return self.forceExport(req, id, req.body.locales, callback);
-      }, {
+      return self.apos.modules['apostrophe-jobs'].runNonBatch(req, run, {
         labels: {
           title: 'Force Export'
         }
       });
+
+      function run(req, reporting, callback) {
+        var results = {};
+        return async.series({
+          addRelated: function(callback) {
+            if (!req.body.related) {
+              return callback(null);
+            }
+            // findRelated is actually quite fast, but fetching 1000 docs
+            // one at a time is not. Fetch batches of 100 docs.
+            var batchSize = 1;
+            req.body.ids = self.apos.launder.ids(req.body.ids);
+            var prepend = [];
+            reporting.setTotal(req.body.ids.length);
+            var unfetched = req.body.ids;
+            return fetchBatch();
+            function fetchBatch() {
+              var batch = unfetched.slice(0, batchSize);
+              if (!batch.length) {
+                req.body.ids = prepend.concat(req.body.ids);
+                req.body.ids = _.uniq(req.body.ids);
+                return callback(null);
+              }
+              unfetched = unfetched.slice(batchSize);
+              return self.findDocs(req, { _id: { $in: batch } }).areas(true).joins(true).toArray(function(err, docs) {
+                if (err) {
+                  return callback(err);
+                }
+                return async.eachLimit(docs, 5, function(doc, callback) { 
+                  return self.getRelated([ doc ], function(err, related) {
+                    if (err) {
+                      return callback(err);
+                    }
+                    prepend = prepend.concat(_.pluck(related, '_id')); 
+                    reporting.setTotal(_.uniq(prepend.concat(req.body.ids)).length);
+                    // getRelated is currently not truly async, don't
+                    // crash the stack
+                    return setImmediate(callback);
+                  });
+                }, function(err) {
+                  if (err) {
+                    return callback(err);
+                  }
+                  return fetchBatch();
+                });
+              });
+            }
+          },
+          forceExport: function(callback) {
+            reporting.setTotal(req.body.ids.length);
+            return async.eachSeries(req.body.ids, function(id, callback) {
+              return self.forceExport(req, id, req.body.locales, function(err, result) {
+                if (err) {
+                  self.apos.utils.error(err);
+                  reporting.bad();
+                } else {
+                  results[id] = result;
+                  reporting.good();
+                }
+                return callback(null);
+              }, callback);
+            }, callback);
+          }
+        }, function(err) {
+          if (err) {
+            self.apos.notify(req, 'An error occurred while identifying related documents.', { type: 'error' });
+          }
+          reporting.setResults(results);
+          return callback(null);
+        });
+      }
     });
 
     self.route('post', 'batch-revert-to-live', function(req, res) {
@@ -742,17 +811,6 @@ module.exports = function(self, options) {
       function getRelated(callback) {
         return self.getRelated([ doc ], function(err, results) {
           related = results;
-          // Discard unless something is actually joined
-          related = _.filter(related, function(relatedOne) {
-            return !!relatedOne;
-          });
-          var seen = {};
-          related = _.filter(related, function(relatedOne) {
-            if (!seen[relatedOne._id]) {
-              seen[relatedOne._id] = true;
-              return true;
-            }
-          });
           return callback(err);
         });
       }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -132,7 +132,9 @@ module.exports = function(self, options) {
             }
             // findRelated is actually quite fast, but fetching 1000 docs
             // one at a time is not. Fetch batches of 100 docs.
-            var batchSize = 1;
+            // Was also tested at batch size 1 to make sure
+            // multiple batches really work.
+            var batchSize = 100;
             req.body.ids = self.apos.launder.ids(req.body.ids);
             var prepend = [];
             reporting.setTotal(req.body.ids.length);

--- a/public/css/user.less
+++ b/public/css/user.less
@@ -161,6 +161,19 @@
   }
 }
 
+.apos-ui .apos-workflow-export-option {
+  margin-top: 6px;
+  max-width: 740px;
+  padding-top: 12px;
+  margin-left: 220px;
+  padding-left: 24px;
+  input {
+    margin-right: 12px;
+  }
+  height: 48px;
+  background-color: @apos-white;
+}
+
 .apos-ui .apos-workflow-locale-picker,
 .apos-ui .apos-workflow-export-locales {
   height: 100%;
@@ -168,6 +181,9 @@
   margin-left: 220px;
   padding-top: @apos-padding-2;
   background-color: @apos-white;
+  &.apos-workflow-export-locales--option {
+    height: ~"calc(100% - 60px)";
+  }
 }
 
 .apos-ui .apos-workflow-locale-picker-items,

--- a/public/js/batch-force-export-modal.js
+++ b/public/js/batch-force-export-modal.js
@@ -17,10 +17,12 @@ apos.define('apostrophe-workflow-batch-force-export-modal', {
         apos.notify('Select at least one locale to export to.', { type: 'error' });
         return callback('user');
       }
+      var related = self.$el.findByName('related').prop('checked');
       // Modifying the `body` object passed to us
       // by batchForceExportGetLocales allows that
       // method to see the locales that were chosen
       self.options.body.locales = locales;
+      self.options.body.related = related;
       return callback(null);
     };
 

--- a/views/batch-force-export-modal.html
+++ b/views/batch-force-export-modal.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {%- block body -%}
-<div class="apos-workflow-export-locales">
+<div class="apos-workflow-export-locales apos-workflow-export-locales--option">
   {{ localeTree.tree(
     'locales',
     [
@@ -34,6 +34,9 @@
     data.nestedLocales)
   }}
 </div>
+<p class="apos-workflow-export-option">
+  <input type="checkbox" name="related">Also force export related documents, such as images
+</p>
 {%- endblock -%}
 
 {%- block footerContainer -%}{%- endblock -%}


### PR DESCRIPTION
This took a surprising amount of effort because I had to refactor the job to run a little differently, in order to make sure that all of the time consuming work — both the search for related documents, and the actual force exporting — takes place in the context of our "long running jobs" feature and not while waiting for a single `req` to return to the browser. Otherwise a timeout would be likely on large batch force exports that include related documents.

A new checkbox to force export the related documents has been added to the bottom of the modal where you pick the locales. My CSS and markup are not glorious, but they seem up to the standard of the locale chooser (he praised faintly). I had to do a bit of working-around because the locale chooser normally wants to be 100% height.

Every effort has been made to make sure the code can cope if the selection is large.

This was developed with the use case of selecting many pages in the page tree via "reorganize" and selecting "batch force export" there in mind. It also should work just fine when used from "manage pieces," because they rely on the same UI and backend code to carry out "batch force export," although it would be a lot less common to initiate that from "manage pieces."