### PR TITLE
Default hostname is clear signal

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -642,17 +642,21 @@ module.exports = function(self, options) {
   // method as you see fit.
 
   self.guessLocale = function(req) {
+    if (!req.locale) {
+      req.locale = self.defaultLocale;
+    }
+  };
+
+  // Get the locale as determined by the default locale specified
+  // for the hostname, if any
+  self.getLocaleViaHostnameDefault = function(req) {
     var host = self.getHost(req);
     var hostname;
     var matches = host.match(/^[^:]+/);
     if (matches) {
       hostname = matches[0];
-      if (self.defaultLocalesByHostname[hostname]) {
-        req.locale = self.defaultLocalesByHostname[hostname];
-        return;
-      }
+      return self.defaultLocalesByHostname[hostname];
     }
-    req.locale = self.defaultLocale;
   };
 
   self.enableCrossDomainSessionCache = function() {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -156,15 +156,19 @@ module.exports = function(self, options) {
       if (candidates.length === 1) {
         setLocale(candidates[0]);
       }
-      req.locale = self.localeInSession(req) ? req.session.locale : req.locale;
 
+      const hostnameDefaultLocale = self.getLocaleViaHostnameDefault(req);
+      if (hostnameDefaultLocale) {
+        setLocale(hostnameDefaultLocale);
+      }
+
+      req.locale = self.localeInSession(req) ? req.session.locale : req.locale;
       // Resort to the default locale if (1) there is no indication of what locale to use,
       // (2) the locale isn't configured, or (3) the locale is private and we don't have
       // permission to view private locales.
 
       if ((!req.locale) || (!_.has(self.locales, req.locale)) ||
         (self.locales[req.locale].private && (!self.apos.permissions.can(req, 'private-locales')))) {
-
         self.guessLocale(req);
         setLocale(req.locale);
       }

--- a/test/test2-disable-anon-session.js
+++ b/test/test2-disable-anon-session.js
@@ -161,6 +161,10 @@ describe('Workflow Subdomains and Prefixes', function() {
         Host: parsed.host
       }[propName];
     };
+    req.res.redirect = function(url) {
+      req.url = url;
+      after(req);
+    };
 
     var workflow = apos.modules['apostrophe-workflow'];
     assert(workflow);
@@ -203,6 +207,13 @@ describe('Workflow Subdomains and Prefixes', function() {
   it('can detect a root-level locale via middleware - case 2', function (done) {
     tryMiddleware('http://example.com/some-url', function (req) {
       assert(req.locale === 'us-en');
+      done();
+    });
+  });
+
+  it('can find a defaultLocaleByHostname-determined locale via middleware', function(done) {
+    tryMiddleware('http://tt.com', function(req) {
+      assert(req.locale === 'tt-one');
       done();
     });
   });
@@ -858,14 +869,6 @@ describe('Workflow Subdomains and Prefixes', function() {
     });
     apos.modules['apostrophe-workflow'].guessLocale(req);
     assert(req.locale === 'default');
-    req = apos.tasks.getAnonReq({
-      locale: false,
-      get: function() {
-        return 'tt.com';
-      }
-    });
-    apos.modules['apostrophe-workflow'].guessLocale(req);
-    assert(req.locale === 'tt-one');
   });
 
 });

--- a/test/test2.js
+++ b/test/test2.js
@@ -156,6 +156,10 @@ describe('Workflow Subdomains and Prefixes', function() {
         Host: parsed.host
       }[propName];
     };
+    req.res.redirect = function(url) {
+      req.url = url;
+      after(req);
+    };
 
     var workflow = apos.modules['apostrophe-workflow'];
     assert(workflow);
@@ -197,6 +201,13 @@ describe('Workflow Subdomains and Prefixes', function() {
   it('can detect a root-level locale via middleware - case 2', function (done) {
     tryMiddleware('http://example.com/some-url', function (req) {
       assert(req.locale === 'us-en');
+      done();
+    });
+  });
+
+  it('can find a defaultLocaleByHostname-determined locale via middleware', function(done) {
+    tryMiddleware('http://tt.com', function(req) {
+      assert(req.locale === 'tt-one');
       done();
     });
   });
@@ -852,14 +863,6 @@ describe('Workflow Subdomains and Prefixes', function() {
     });
     apos.modules['apostrophe-workflow'].guessLocale(req);
     assert(req.locale === 'default');
-    req = apos.tasks.getAnonReq({
-      locale: false,
-      get: function() {
-        return 'tt.com';
-      }
-    });
-    apos.modules['apostrophe-workflow'].guessLocale(req);
-    assert(req.locale === 'tt-one');
   });
 
 });


### PR DESCRIPTION
If defaultLocaleByHostname states that the locale should be set, that should be a firm signal that always sets req.locale (after first checking for even better signals like hostname-plus-prefix), not a weak signal that waits for the guessLocale mechanism that only comes in if req.locale is completely empty.

Otherwise a preexisting default req.locale, as seen on DGAD, breaks this mechanism.