### PR TITLE
fix crashing bug when a child page is force exported but its parent i…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -175,7 +175,7 @@ module.exports = function(self, options) {
       move
     ], function(err) {
       if (err === 'notfound') {
-        self.apos.notify(req, 'The most recent move of the page in the tree could not be duplicated as part of the commit.');
+        self.apos.notify(req, 'The most recent movement of the page in the tree could not be duplicated as part of the commit.');
         err = null;
       }
       return callback(null);
@@ -185,10 +185,10 @@ module.exports = function(self, options) {
         if (err) {
           return callback(err);
         }
-        targetId = info._id;
-        if (!targetId) {
+        if (!info) {
           return callback('notfound');
         }
+        targetId = info._id;
         return callback(null);
       });
     }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -172,6 +172,19 @@ module.exports = function(self, options) {
               });
             }
           },
+          sortIds: function(callback) {
+            if (!req.body.ids.length) {
+              return callback(null);
+            }
+            // Ensure pages are force-exported parents-first
+            return self.apos.docs.db.find({ _id: { $in: req.body.ids } }).project({ _id: 1 }).sort({ level: 1, rank: 1 }).toArray(function(err, docs) {
+              if (err) {
+                return callback(err);
+              }
+              req.body.ids = _.pluck(docs, '_id');
+              return callback(null);
+            });
+          },
           forceExport: function(callback) {
             reporting.setTotal(req.body.ids.length);
             return async.eachSeries(req.body.ids, function(id, callback) {


### PR DESCRIPTION
…s not in the target locale, which should make it a child of the home page in that locale. Unit test for that situation (test fails without the fix in place). Guarantee that "Force Export" processes pages parent first, to minimize odd page tree outcomes.