### PR TITLE
Fix overflow issue with apos-workflow-preview

### DIFF
--- a/public/css/user.less
+++ b/public/css/user.less
@@ -11,10 +11,10 @@
 {
   width: 100%;
   height: 100%;
+  position: relative;
   box-sizing: border-box;
   border: 0;
   margin: 0;
-  margin-top: -40px;
   padding: 0;
   transform: scale(0.8);
   border-bottom-left-radius: 10px;
@@ -22,6 +22,10 @@
   box-shadow: 0 10px 190px 0 rgba(0,0,0,.25);
   &::before {
     content: "● ● ●";
+    position: absolute;
+    top: -59px;
+    left: 0;
+    width: 100%;
     color: #ffffff;
     text-align: left;
     font-size: 1.5em;


### PR DESCRIPTION
The height of the Preview Iframe was set to 100% of the parent which meant it didn't take into account the height of the before element. Content ends up overflowing out of the Iframe. Fixed it by making the before pseudo-element position absolute.

![iframe](https://user-images.githubusercontent.com/12910216/67069821-fab68000-f19b-11e9-9e4c-3ff6b26114fc.png)
