### PR TITLE
disambiguate the locale an API request is intended for using a header…

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -79,7 +79,8 @@ module.exports = function(self, options) {
         }
       }
 
-      if (req.headers['apostrophe-locale']) {
+      // test reqs might not have a headers object
+      if (req.headers && req.headers['apostrophe-locale']) {
         if (_.has(self.locales, req.headers['apostrophe-locale'])) {
           setLocale(req.headers['apostrophe-locale']);
           return next();

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -79,6 +79,13 @@ module.exports = function(self, options) {
         }
       }
 
+      if (req.headers['apostrophe-locale']) {
+        if (_.has(self.locales, req.headers['apostrophe-locale'])) {
+          setLocale(req.headers['apostrophe-locale']);
+          return next();
+        }
+      }
+
       // Start with all of the non-draft locales as candidates
       // (we implement draft vs. live at the end)
 

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -19,6 +19,7 @@ apos.define('apostrophe-workflow', {
     self.enableForceExport();
     self.enableForceExportWidget();
     self.enableCrossDomainSessionToken();
+    self.enableLocaleHeader();
   },
 
   construct: function(self, options) {
@@ -740,6 +741,14 @@ apos.define('apostrophe-workflow', {
         window.location.href = href;
       });
     };
-
+    self.enableLocaleHeader = function() {
+      // AJAX requests include a locale header to work around the fact
+      // that we only prefix page URLs with a locale prefix
+      $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+        if ((options.type !== 'OPTIONS') && (!options.crossDomain)) {
+          jqXHR.setRequestHeader('Apostrophe-Locale', self.locale);
+        }
+      });
+    };
   }
 });


### PR DESCRIPTION
…, as they do not have locale prefixes and that would be a major bc break to add