### PR TITLE
when an attachment property changes it should be possible to export it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.28.1
+
+* When exporting a commit to another locale, a change in an attachment property is now properly applied as part of the patch.
+
 ## 2.28.0
 
 * Joins in `object` fields now remap properly when committing. Thanks to Eric Wong for this contribution.

--- a/lib/api.js
+++ b/lib/api.js
@@ -1333,7 +1333,7 @@ module.exports = function(self, options) {
     purgeObjects(from, fromObjects);
     purgeObjects(to, toObjects);
 
-    // Step 4: patch with jsondiff for everything that doesn't have an _id
+    // Step 4: patch with jsondiff for everything else
 
     if (description) {
       // We don't do jsondiff when just generating a widget change description
@@ -1354,7 +1354,7 @@ module.exports = function(self, options) {
       var dots = {};
 
       self.apos.docs.walk(doc, function(doc, key, value, dotPath, ancestors) {
-        if (value && (typeof (value) === 'object') && value._id) {
+        if (value && (typeof (value) === 'object') && value._id && (value.type !== 'attachment')) {
           objects.push(value);
           dotPaths[value._id] = dotPath;
           dots[value._id] = 0;
@@ -1861,6 +1861,7 @@ module.exports = function(self, options) {
         }
 
         function applyPatch(callback) {
+
           self.deleteExcludedProperties(from);
           self.deleteExcludedProperties(to);
 

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
   "scripts": {
     "test": "mocha && eslint ."
   },
-  "version": "2.28.0"
+  "version": "2.28.1"
 }


### PR DESCRIPTION
Currently the algorithm for applying a previous commit as a patch to another locale sweeps up all sub-properties of the document with an _id and treats them like widgets or array elements, seeking a match in the destination locale to apply the patch to, etc.

That's good for those but not great for attachment properties which have an _id but are part of the doc itself and should be handled by the patch algorithm that handles simple properties like `slug`. Exempt attachment properties from this step of the algorithm.

Needed for apostrophe-favicons 3.x, and also for allowing replacement of images in the media library to be exported properly across locales.