### PR TITLE
private locales locked down even if they have hostnames, subdomains, …

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -109,6 +109,11 @@ module.exports = function(self, options) {
         if (matches) {
           hostname = matches[0];
           candidates = _.filter(candidates, function(candidate) {
+            if (self.locales[candidate] && self.locales[candidate].private) {
+              if (!self.apos.permissions.can(req, 'private-locales')) {
+                return false;
+              }
+            }
             return self.hostnames[candidate] === hostname;
           });
         }
@@ -172,11 +177,24 @@ module.exports = function(self, options) {
 
       // If we made it down to one locale, that's the winner
       if (candidates.length === 1) {
-        setLocale(candidates[0]);
+        var privateLocale = self.locales[candidates[0]] && self.locales[candidates[0]].private;
+        if (privateLocale) {
+          if (self.apos.permissions.can(req, 'private-locales')) {
+            setLocale(candidates[0]);
+          }
+        } else {
+          setLocale(candidates[0]);
+        }
       }
       const hostnameDefaultLocale = self.getLocaleViaHostnameDefault(req);
       if (hostnameDefaultLocale && (!setByUs)) {
-        setLocale(hostnameDefaultLocale);
+        if (self.locales[hostnameDefaultLocale] && self.locales[hostnameDefaultLocale].private) {
+          if (self.apos.permissions.can(req, 'private-locales')) {
+            setLocale(hostnameDefaultLocale);
+          }
+        } else {
+          setLocale(hostnameDefaultLocale);
+        }
       }
 
       req.locale = self.localeInSession(req) ? req.session.locale : req.locale;

--- a/test/test2-disable-anon-session.js
+++ b/test/test2-disable-anon-session.js
@@ -21,12 +21,12 @@ describe('Workflow Subdomains and Prefixes', function() {
       testModule: true,
 
       modules: {
+        'products': {},
         'apostrophe-express': {
-          csrf: {
-            disableAnonSession: true
-          }
-        },
-        products: {},
+           csrf: {
+             disableAnonSession: true
+           }
+         },
         'apostrophe-pages': {
           park: [],
           types: [
@@ -42,6 +42,7 @@ describe('Workflow Subdomains and Prefixes', function() {
         },
         'apostrophe-workflow': {
           hostnames: {
+            'private': 'private.com',
             'fr': 'exemple.fr',
             'default': 'example.com',
             'us': 'example.com',
@@ -127,13 +128,22 @@ describe('Workflow Subdomains and Prefixes', function() {
                 },
                 {
                   name: 'tt-three'
+                },
+                {
+                  name: 'private',
+                  private: true
+                },
+                {
+                  name: 'private2',
+                  private: true
                 }
               ]
             }
           ],
           defaultLocale: 'default',
           defaultLocalesByHostname: {
-            'tt.com': 'tt-one'
+            'tt.com': 'tt-one',
+            'private2.com': 'private2'
           }
         }
       },
@@ -151,7 +161,20 @@ describe('Workflow Subdomains and Prefixes', function() {
   });
 
   function tryMiddleware(url, after) {
-    var req = apos.tasks.getAnonReq();
+    return tryMiddlewareBody(url, {}, after);
+  }
+
+  function tryMiddlewareAdmin(url, after) {
+    return tryMiddlewareBody(url, { admin: true }, after);
+  }
+
+  function tryMiddlewareBody(url, options, after) {
+    var req;
+    if (options.admin) {
+      req = apos.tasks.getReq();
+    } else {
+      req = apos.tasks.getAnonReq();
+    }
     req.absoluteUrl = url;
     var parsed = require('url').parse(req.absoluteUrl);
     req.url = parsed.path;
@@ -171,7 +194,6 @@ describe('Workflow Subdomains and Prefixes', function() {
     var middleware = workflow.expressMiddleware.middleware;
 
     middleware(req, req.res, function() {
-      assert(req.locale && (!req.session.locale));
       after(req);
     });
   }
@@ -204,6 +226,7 @@ describe('Workflow Subdomains and Prefixes', function() {
     });
   });
 
+  
   it('can detect a root-level locale via middleware - case 2', function (done) {
     tryMiddleware('http://example.com/some-url', function (req) {
       assert(req.locale === 'us-en');
@@ -214,6 +237,55 @@ describe('Workflow Subdomains and Prefixes', function() {
   it('can find a defaultLocaleByHostname-determined locale via middleware', function(done) {
     tryMiddleware('http://tt.com', function(req) {
       assert(req.locale === 'tt-one');
+      done();
+    });
+  });
+
+  it('can find a jointly determined locale via middleware when a defaultLocaleByHostname is also present', function(done) {
+    tryMiddleware('http://tt.com/two', function(req) {
+      assert(req.locale === 'tt-two');
+      done();
+    });
+  });
+
+  it('can detect a jointly determined private locale via prefix when we have permission', function(done) {
+    tryMiddlewareAdmin('http://example.com/us-private', function(req) {
+      assert(req.locale === 'us');
+      done();
+    });
+  });
+
+  it('cannot detect a jointly determined private locale via prefix when we do not have permission', function(done) {
+    tryMiddleware('http://example.com/us-private', function(req) {
+      assert(req.locale === 'us-en');
+      done();
+    });
+  });
+
+  it('can detect a hostname determined private locale via hostname when we have permission', function(done) {
+    tryMiddlewareAdmin('http://private.com/', function(req) {
+      assert(req.locale === 'private');
+      done();
+    });
+  });
+
+  it('cannot detect hostname determined private locale via prefix when we do not have permission', function(done) {
+    tryMiddleware('http://private.com/', function(req) {
+      assert(req.locale !== 'private');
+      done();
+    });
+  });
+
+  it('can detect a defaultLocaleByHostname-determined private locale via hostname when we have permission', function(done) {
+    tryMiddlewareAdmin('http://private2.com/', function(req) {
+      assert(req.locale === 'private2');
+      done();
+    });
+  });
+
+  it('cannot detect defaultLocaleByHostname-determined private locale via prefix when we do not have permission', function(done) {
+    tryMiddleware('http://private2.com/', function(req) {
+      assert(req.locale !== 'private2');
       done();
     });
   });
@@ -743,7 +815,11 @@ describe('Workflow Subdomains and Prefixes', function() {
       'tt-two',
       'tt-two-draft',
       'tt-three',
-      'tt-three-draft'
+      'tt-three-draft',
+      'private',
+      'private-draft',
+      'private2',
+      'private2-draft'
     ];
     assert(_.isEqual(locales, $in));
   });


### PR DESCRIPTION
…prefixes, or defaultLocaleByHostname configuration

Fixes DGAD-927