### PR TITLE
batch force export was broken for cases where related documents were …

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -133,6 +133,12 @@ module.exports = function(self, options) {
         return async.series({
           addRelated: function(callback) {
             if (!req.body.related) {
+              tasks = ids.map(function(id) {
+                return {
+                  _id: id,
+                  existing: true
+                };
+              });
               return callback(null);
             }
             // findRelated is actually quite fast, but fetching 1000 docs


### PR DESCRIPTION
…*not* included. Due to an omission.