### PR TITLE
Make default workflow mode configurable

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -6,6 +6,8 @@ const ExpressSessionCookie = require('express-session/session/cookie');
 
 module.exports = function(self, options) {
 
+  self.defaultMode = ['live', 'draft', 'preview'].includes(options.defaultMode) ? options.defaultMode : 'draft';
+
   self.localized = false;
 
   self.composeLocales = function() {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -209,12 +209,18 @@ module.exports = function(self, options) {
       }
 
       if (req.user) {
-        if (req.session.workflowMode === 'draft') {
-          req.locale = self.draftify(req.locale);
-        } else {
+        // Handle preview mode first
+        if (!req.session.workflowMode && self.defaultMode === 'preview') {
+          req.session.workflowPreview = true;
+        }
+
+        req.session.workflowMode = req.session.workflowMode || self.defaultMode;
+        if (req.session.workflowMode === 'live') {
           req.locale = self.liveify(req.locale);
-          // Default mode is previewing the live content, not editing
           req.session.workflowMode = 'live';
+        } else {
+          req.locale = self.draftify(req.locale);
+          req.session.workflowMode = 'draft';
         }
       }
 


### PR DESCRIPTION
Adds an option `defaultMode` to apostrophe-workflow to define which mode it should pick when the user has just logged in. (see https://github.com/apostrophecms/apostrophe-workflow/issues/174)

- `options.defaultMode` can be any of `live`, `draft` or `preview`
- if `options.defaultMode` is not set, or set to any other value, `draft` will be used (no warning raised)