### PR TITLE
send locale header in lean mode API calls too. When logged out and us…

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -14,5 +14,6 @@ module.exports = function(self, options) {
     self.pushAsset('script', 'batch-force-export-modal', { when: 'user' });
     self.pushAsset('script', 'locale-unavailable-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'user', { when: 'user' });
+    self.pushAsset('script', 'lean', { when: 'lean' });
   };
 };

--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -322,6 +322,8 @@ module.exports = function(self, options) {
 
   self.pageBeforeSend = function(req, callback) {
 
+    self.apos.templates.addBodyDataAttribute(req, 'locale', req.locale);
+
     // If looking at a live locale, disable inline editing
     // Also adds a class on <body> for both workflow modes
     if (req.user) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -86,7 +86,7 @@ module.exports = function(self, options) {
           // To avoid race conditions that can break locale switching,
           // we don't modify the session based on the header
           if (self.apos.hasOwnProperty('i18n')) {
-            // Careful, i18n.setLocale does not grasp default locales
+            // Careful, i18n.setLocale does not grasp draft locales
             self.apos.i18n.setLocale(req, self.liveify(req.headers['apostrophe-locale']));
           }
           req.locale = req.headers['apostrophe-locale'];

--- a/public/js/lean.js
+++ b/public/js/lean.js
@@ -1,0 +1,15 @@
+(function() {
+  console.log('executing');
+  document.body.addEventListener('apos-before-get', addLocaleHeader);
+  document.body.addEventListener('apos-before-post', addLocaleHeader);
+  function addLocaleHeader(event) {
+    console.log('in listener');
+    // Easy check for same origin
+    var link = document.createElement('a');
+    link.href = event.uri;
+    if (link.host !== location.host) {
+      return;
+    }
+    event.request.setRequestHeader('Apostrophe-Locale', document.body.getAttribute('data-locale'));
+  };
+})();

--- a/public/js/lean.js
+++ b/public/js/lean.js
@@ -1,9 +1,7 @@
 (function() {
-  console.log('executing');
   document.body.addEventListener('apos-before-get', addLocaleHeader);
   document.body.addEventListener('apos-before-post', addLocaleHeader);
   function addLocaleHeader(event) {
-    console.log('in listener');
     // Easy check for same origin
     var link = document.createElement('a');
     link.href = event.uri;


### PR DESCRIPTION
…ing URL prefixes for locales, this is necessary to affect the right locale without making every single bingle API call that any developer makes specifically locale aware, because APIs are not URL-prefixed by locale