### PR TITLE
tolerate a missing type property when trying to find joins in docs fo…

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -301,6 +301,12 @@ module.exports = function(self, options) {
   // its doc type manager, and return the result.
 
   self.findJoinsInDocSchema = function(doc) {
+    if (!doc.type) {
+      // Cannot determine schema, so we cannot fetch joins;
+      // don't crash, so we behave reasonably if very light
+      // projections are present
+      return [];
+    }
     var schema = self.apos.docs.getManager(doc.type).schema;
     return self.findJoinsInSchema(doc, schema);
   };
@@ -318,6 +324,10 @@ module.exports = function(self, options) {
     });
     var joins = [];
     _.each(widgets, function(widget) {
+      if (!widget.type) {
+        // Don't crash on bad data or strange projections etc.
+        return;
+      }
       var manager = self.apos.areas.getWidgetManager(widget.type);
       if (!manager) {
         // We already warn about obsolete widgets elsewhere, don't crash


### PR DESCRIPTION
…r purposes of locating related docs. We cannot find them without a type, but we should not crash.