### PR TITLE
Slug updated twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.38.3 (2021-03-01)
+* Fixes page slug updated twice when committing a page move.
+
 ## 2.38.2 (2020-10-21)
 
 * Sets the new `forbiddenFields` option for the Manage Workflow view, a "virtual" piece type which has the unusual property of viewing content of all types, to an empty array.

--- a/lib/api.js
+++ b/lib/api.js
@@ -203,7 +203,8 @@ module.exports = function(self, options) {
           },
           filters: {
             workflowLocale: to.workflowLocale
-          }
+          },
+          slugUpdated: true
         },
         callback
       );

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -179,7 +179,7 @@ module.exports = {
               target: info.target.workflowGuid,
               position: info.position
             },
-            workflowMovedIsNew: true
+            ...moved.workflowLocale.includes('-draft') && { workflowMovedIsNew: true }
           }
         }, callback);
       });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.38.2",
+  "version": "2.38.3",
   "scripts": {
     "test": "mocha && eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "description": "Workflow, approvals, localization and internationalization for ApostropheCMS",
   "bundleDependencies": false,
   "peerDependencies": {
-    "apostrophe": "^2.107.0"
+    "apostrophe": "^2.116.1"
   },
   "dependencies": {
     "@sailshq/lodash": "^3.10.3",


### PR DESCRIPTION
With workflow, when we commit a page move, the slug is updated using the draft one in workflow. Then it calls the `self.move` method of `apostrophe-pages`, inside the slug is updated again.
This behavior produces bad slugs by duplicating it, example `/block-page/sub-page` becomes `/block-page/block-page/sub-page`.