### PR TITLE
Moves draft and live pages at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.39.0 (2021-04-20)
-* Adds `syncPagesMoves` flag to move live pages at the same time than draft ones, without committing.
+* Adds `autoCommitPageMoves` flag to move live pages at the same time than draft ones, without committing.
 
 ## 2.38.3 (2021-03-01)
 * Fixes page slug updated twice when committing a page move.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.39.0 (2021-04-20)
+* Adds `syncPagesMoves` flag to move live pages at the same time than draft ones, without committing.
+
 ## 2.38.3 (2021-03-01)
 * Fixes page slug updated twice when committing a page move.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.39.0 (2021-04-20)
-* Adds `autoCommitPageMoves` flag to move live pages at the same time than draft ones, without committing.
+* Adds `autoCommitPageMoves` flag to commit only pages moves automatically.
 
 ## 2.38.3 (2021-03-01)
 * Fixes page slug updated twice when committing a page move.

--- a/README.md
+++ b/README.md
@@ -927,11 +927,11 @@ To avoid this behavior and move draft and live pages at the same time, you can p
 
 ```javascript
 'apostrophe-workflow': {
-  syncPagesMoves: true,
+  autoCommitPageMoves: true,
 }
 ```
 
-:warning: It won't commit it, it will just update properties linked to the pages tree like `path`, `rank`, `level` and `workflowMoved`. So the slug, for example, will be updated only when committing.
+:warning: This will only commit the new position in the tree of a moved page. It will not commit any other properties of the page, such as the `slug` or `title`.
 
 ### Previewing piece types without an index page
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ We'll begin with the steps needed simply to add workflow to your project. Then w
 - [Other developer concerns](#user-content-other-developer-concerns)
   * [Aliasing the module](#user-content-aliasing-the-module)
   * [Excluding certain types and properties from workflow](#excluding-certain-types-and-properties-from-workflow)
+  * [Managing the pages tree without workflow](#managing-the-pages-tree-without-workflow)
   * [Previewing piece types without an index page](#user-content-previewing-piece-types-without-an-index-page)
   * [Command line tasks and workflow](#user-content-command-line-tasks-and-workflow)
     + [Using the `-workflow-locale` option](#user-content-using-the-workflow-locale-option)
@@ -915,6 +916,22 @@ To exclude a property, write:
 ```
 
 **The property is excluded for all doc types.** Use a name that is unambiguous for such properties.
+
+### Managing the pages tree without workflow
+
+With the normal `apostrophe-workflow` behavior, when you move a page in the page tree modal, it only moves the draft one. Later, when committing, it will move the live one too. The draft document is moved relatively to a target (it can be `before`, `after` or `inside`), the live one is moved relatively to the live version of this target.
+
+In some cases, when moving too much nested pages without committing each one before, it can generate mismatches between draft and live pages trees and lead to confusion.
+
+To avoid this behavior and move draft and live pages at the same time, you can pass this flag to you workflow config:
+
+```javascript
+'apostrophe-workflow': {
+  syncPagesMoves: true,
+}
+```
+
+:warning: It won't commit it, it will just update properties linked to the pages tree like `path`, `rank`, `level` and `workflowMoved`. So the slug, for example, will be updated only when committing.
 
 ### Previewing piece types without an index page
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ module.exports = {
     self.enableHarmonizeWorkflowGuidsByParkedIdTask();
     self.enableDiffDraftAndLiveTask();
     self.enableReplicateLocaleTask();
+    self.cleanPagesTree();
     self.pushAssets();
     self.addToAdminBar();
     self.apos.pages.addAfterContextMenu(self.menu);

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = {
     self.enableHarmonizeWorkflowGuidsByParkedIdTask();
     self.enableDiffDraftAndLiveTask();
     self.enableReplicateLocaleTask();
-    self.cleanPagesTree();
+    self.enableCleanPagesTreeTask();
     self.pushAssets();
     self.addToAdminBar();
     self.apos.pages.addAfterContextMenu(self.menu);
@@ -87,6 +87,11 @@ module.exports = {
     self.composeApiCalls();
     self.addWorkflowModifiedMigration();
     self.addWorkflowLastCommittedMigration();
+
+    if (self.options.autoCommitPageMoves) {
+      self.addPagesTreeCleaningMigration();
+    }
+
     self.on('apostrophe-pages:beforeParkAll', 'updateHistoricalPrefixesPromisified', function() {
       return Promise.promisify(self.updateHistoricalPrefixes)();
     });

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = {
     self.enableHarmonizeWorkflowGuidsByParkedIdTask();
     self.enableDiffDraftAndLiveTask();
     self.enableReplicateLocaleTask();
-    self.enableCleanPagesTreeTask();
+    self.enableSyncPagesTreeTask();
     self.pushAssets();
     self.addToAdminBar();
     self.apos.pages.addAfterContextMenu(self.menu);

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,7 +23,7 @@ var diff = require('jsondiffpatch').create({
   }
 });
 
-module.exports = function(self, { syncPagesMoves }) {
+module.exports = function(self, { autoCommitPageMoves }) {
   // Resolve relationships between this doc and other docs, which need to be
   // mapped to the appropriate doc in the new locale, via the workflowGuid
   // property of each doc.
@@ -307,7 +307,7 @@ module.exports = function(self, { syncPagesMoves }) {
       }, callback);
     }
     function move(callback) {
-      if (!from.workflowMovedIsNew || syncPagesMoves) {
+      if (!from.workflowMovedIsNew || autoCommitPageMoves) {
         return callback(null);
       }
 
@@ -1073,14 +1073,20 @@ module.exports = function(self, { syncPagesMoves }) {
     });
 
     function getTrashedDraftDocs(callback) {
-      return self.apos.docs.find(req, { workflowModified: true }, { _id: 1, workflowGuid: 1 }).trash(true).published(null).toArray(function(err, docs) {
-        if (err) {
-          return callback(err);
-        }
+      return self.apos.docs.find(req, {
+        workflowModified: true
+      }, {
+        _id: 1, workflowGuid: 1
+      }).trash(true)
+        .published(null)
+        .toArray(function(err, docs) {
+          if (err) {
+            return callback(err);
+          }
 
-        workflowGuids = _.pluck(docs, 'workflowGuid');
-        return callback();
-      });
+          workflowGuids = _.pluck(docs, 'workflowGuid');
+          return callback();
+        });
     }
 
     function getUntrashedLiveDocs(callback) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,8 +23,7 @@ var diff = require('jsondiffpatch').create({
   }
 });
 
-module.exports = function(self, options) {
-
+module.exports = function(self, { syncPagesMoves }) {
   // Resolve relationships between this doc and other docs, which need to be
   // mapped to the appropriate doc in the new locale, via the workflowGuid
   // property of each doc.
@@ -181,7 +180,10 @@ module.exports = function(self, options) {
       return callback(null);
     });
     function getTargetId(callback) {
-      return self.apos.docs.db.findOne({ workflowGuid: from.workflowMoved.target, workflowLocale: to.workflowLocale }, { _id: 1 }, function(err, info) {
+      return self.apos.docs.db.findOne({
+        workflowGuid: from.workflowMoved.target,
+        workflowLocale: to.workflowLocale
+      }, { _id: 1 }, function(err, info) {
         if (err) {
           return callback(err);
         }
@@ -305,9 +307,10 @@ module.exports = function(self, options) {
       }, callback);
     }
     function move(callback) {
-      if (!from.workflowMovedIsNew) {
+      if (!from.workflowMovedIsNew || syncPagesMoves) {
         return callback(null);
       }
+
       return self.repeatMove(req, from, to, callback);
     }
     function emit(callback) {
@@ -347,30 +350,36 @@ module.exports = function(self, options) {
     });
     function getOne(callback) {
       // Do not use .permission here, it is too conservative, check ._edit. -Tom
-      return self.findDocs(req, { _id: id }).areas((options.areas === undefined) ? true : options.areas).joins((options.joins === undefined) ? true : options.joins).toObject(function(err, _one) {
-        if (err) {
-          return callback(err);
-        }
-        if (!_one) {
-          return callback('notfound');
-        }
-        if ((options.permission !== false) && !_one._edit) {
-          return callback('notfound');
-        }
-        if (!self.includeType(_one.type)) {
-          return callback('invalid');
-        }
-        if (_one.workflowLocale && _one.workflowLocale.match(/-draft$/)) {
-          draft = _one;
-        } else {
-          live = _one;
-        }
-        return callback(null);
-      });
+      return self.findDocs(req, { _id: id })
+        .areas((options.areas === undefined) ? true : options.areas)
+        .joins((options.joins === undefined) ? true : options.joins)
+        .toObject(function(err, _one) {
+          if (err) {
+            return callback(err);
+          }
+          if (!_one) {
+            return callback('notfound');
+          }
+          if ((options.permission !== false) && !_one._edit) {
+            return callback('notfound');
+          }
+          if (!self.includeType(_one.type)) {
+            return callback('invalid');
+          }
+          if (_one.workflowLocale && _one.workflowLocale.match(/-draft$/)) {
+            draft = _one;
+          } else {
+            live = _one;
+          }
+          return callback(null);
+        });
     }
     function getTwo(callback) {
       var locale = draft ? self.liveify(draft.workflowLocale) : self.draftify(live.workflowLocale);
-      return self.findDocs(req, { workflowGuid: (draft || live).workflowGuid }, locale).areas(true).joins(true).toObject(function(err, _two) {
+
+      return self.findDocs(req, {
+        workflowGuid: (draft || live).workflowGuid
+      }, locale).areas(true).joins(true).toObject(function(err, _two) {
         if (err) {
           return callback(err);
         }
@@ -2409,7 +2418,10 @@ module.exports = function(self, options) {
     }
 
     function getLive(callback) {
-      return self.findDocs(req, { workflowGuid: draft.workflowGuid, workflowLocale: self.liveify(draft.workflowLocale) }).toObject(function(err, doc) {
+      return self.findDocs(req, {
+        workflowGuid: draft.workflowGuid,
+        workflowLocale: self.liveify(draft.workflowLocale)
+      }).toObject(function(err, doc) {
         if (err) {
           return callback(err);
         }

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -1574,6 +1574,12 @@ module.exports = function(self, options) {
     }, { safe: true });
   };
 
+  self.addPagesTreeCleaningMigration = function() {
+    self.apos.migrations.add('pagesTreeCleaning', function() {
+      return self.cleanPagesTree();
+    }, { safe: true });
+  };
+
   // Returns true if the given doc should always replicate across locales when inserted. By default
   // this returns true for all docs subject to workflow. If the `replicateAcrossLocales` option
   // is not `true`, it is only true for parked pages (including the home page) and the global doc.

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -1575,7 +1575,7 @@ module.exports = function(self, options) {
   };
 
   self.addPagesTreeCleaningMigration = function() {
-    self.apos.migrations.add('pagesTreeCleaning', function() {
+    self.apos.migrations.add('05262021-aposPagesTreeCleaning', function() {
       return self.syncPagesTree();
     }, { safe: true });
   };

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -1575,7 +1575,7 @@ module.exports = function(self, options) {
   };
 
   self.addPagesTreeCleaningMigration = function() {
-    self.apos.migrations.add('05262021-aposPagesTreeCleaning', function() {
+    self.apos.migrations.add('01062021-aposPagesTreeCleaning', function() {
       return self.syncPagesTree();
     }, { safe: true });
   };

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -1576,7 +1576,7 @@ module.exports = function(self, options) {
 
   self.addPagesTreeCleaningMigration = function() {
     self.apos.migrations.add('pagesTreeCleaning', function() {
-      return self.cleanPagesTree();
+      return self.syncPagesTree();
     }, { safe: true });
   };
 

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -30,7 +30,7 @@ module.exports = {
 
   },
 
-  construct: function(self, options) {
+  construct: function(self, { syncPagesMoves }) {
 
     var superGetPathIndexParams = self.getPathIndexParams;
     self.getPathIndexParams = function() {
@@ -163,10 +163,14 @@ module.exports = {
     // without attempting to reconcile differences in where the
     // destination parent page happens to be at the start
     // of the operation.
+    // If the syncPagesMoves option has been set, we move the live version
+    // when we move the draft one, in order to avoid any page tree conflicts.
 
     var superAfterMove = self.afterMove;
     self.afterMove = function(req, moved, info, callback) {
       return superAfterMove(req, moved, info, function(err) {
+        const isDraft = moved.workflowLocale.includes('-draft');
+
         if (err) {
           return callback(err);
         }
@@ -179,9 +183,21 @@ module.exports = {
               target: info.target.workflowGuid,
               position: info.position
             },
-            ...moved.workflowLocale.includes('-draft') && { workflowMovedIsNew: true }
+            ...isDraft && { workflowMovedIsNew: true }
           }
-        }, callback);
+        }, (err) => {
+          if (err || !isDraft || !syncPagesMoves) {
+            return callback(err || null);
+          }
+
+          self.apos.workflow.getDraftAndLive(req, moved._id, {}, (err, draft, live) => {
+            if (err) {
+              return callback(err);
+            }
+
+            return self.apos.workflow.repeatMove(req, draft, live, callback);
+          });
+        });
       });
     };
 

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -30,7 +30,7 @@ module.exports = {
 
   },
 
-  construct: function(self, { syncPagesMoves }) {
+  construct: function(self, { autoCommitPageMoves }) {
 
     var superGetPathIndexParams = self.getPathIndexParams;
     self.getPathIndexParams = function() {
@@ -163,7 +163,7 @@ module.exports = {
     // without attempting to reconcile differences in where the
     // destination parent page happens to be at the start
     // of the operation.
-    // If the syncPagesMoves option has been set, we move the live version
+    // If the autoCommitPageMoves option has been set, we move the live version
     // when we move the draft one, in order to avoid any page tree conflicts.
 
     var superAfterMove = self.afterMove;
@@ -186,7 +186,7 @@ module.exports = {
             ...isDraft && { workflowMovedIsNew: true }
           }
         }, (err) => {
-          if (err || !isDraft || !syncPagesMoves) {
+          if (err || !isDraft || !autoCommitPageMoves) {
             return callback(err || null);
           }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -626,8 +626,6 @@ module.exports = function(self, options) {
         }
       ).toArray();
 
-      console.log('pages ===> ', require('util').inspect(pages, { colors: true, depth: 2 }));
-
       // We group pages by workflowGuid
       const groupedPages = pages.reduce((acc, page) => {
         const isDraft = page.workflowLocale.includes('-draft');

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -600,13 +600,20 @@ module.exports = function(self, options) {
     const locales = Object.keys(self.apos.workflow.locales)
       .filter((locale) => !locale.includes('-draft'));
 
-    const pageTypes = self.apos.modules['apostrophe-pages'].options.types.map((type) => type.name);
-
     for (const locale of locales) {
       const pages = await self.apos.docs.db.find(
         {
           workflowLocale: {$in: [locale, self.draftify(locale)]},
-          type: { $in: pageTypes }
+          // Getting all documents with a slug starting by / to get all pages (parked ones too)
+          $and: [
+            {
+              slug: /^\//
+            },
+            {
+              // TO we want to avoid trash page here or we don't need ?
+              slug: { $ne: '/trash' }
+            }
+          ]
         },
         {
           _id: 1,
@@ -618,6 +625,8 @@ module.exports = function(self, options) {
           workflowMoved: 1
         }
       ).toArray();
+
+      console.log('pages ===> ', require('util').inspect(pages, { colors: true, depth: 2 }));
 
       // We group pages by workflowGuid
       const groupedPages = pages.reduce((acc, page) => {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -588,7 +588,7 @@ module.exports = function(self, options) {
     console.log('... Done.');
   };
 
-  self.cleanPagesTreeTask = function() {
+  self.enableCleanPagesTreeTask = function() {
     self.addTask('clean-pages-tree',
       `Cleans your pages tree in the case the live one differs with the draft one,
       The live tree will be modified based on the draft one.`,
@@ -597,8 +597,6 @@ module.exports = function(self, options) {
   };
 
   self.cleanPagesTree = async function() {
-    // const req = self.apos.tasks.getReq();
-
     const locales = Object.keys(self.apos.workflow.locales)
       .filter((locale) => !locale.includes('-draft'));
 
@@ -625,24 +623,26 @@ module.exports = function(self, options) {
       }, {});
 
       for (const { draft, live } of Object.values(groupedPages)) {
-        // const draftTarget = draft.workflowMoved && draft.workflowMoved.target;
-        // const targetPage = pages.filter((page) => page.workflowGuid === draftTarget);
 
-        console.log('draft ===> ', require('util').inspect(draft, { colors: true, depth: 2 }));
+        console.log('draft workflowMoved ===> ', require('util').inspect(draft.workflowMoved, { colors: true, depth: 2 }));
 
-        console.log('live ===> ', require('util').inspect(live, { colors: true, depth: 2 }));
+        console.log('live workflowMoved ===> ', require('util').inspect(live.workflowMoved, { colors: true, depth: 2 }));
 
-        // await self.apos.docs.db.update({
-        //   _id: live._id
-        // }, {
-        //   $set: {
-        //     rank: draft.rank,
-        //     path: draft.path,
-        //     level: draft.level,
-        //     ...draft.workflowModified && draft.workflowModified,
-        //     ...draft.workflowMoved && draft.workflowMoved
-        //   }
-        // });
+        try {
+          await self.apos.docs.db.update({
+            _id: live._id
+          }, {
+            $set: {
+              rank: draft.rank,
+              path: draft.path,
+              level: draft.level,
+              ...draft.workflowModified && { workflowModified: draft.workflowModified },
+              ...draft.workflowMoved && { workflowMoved: draft.workflowMoved }
+            }
+          });
+        } catch (err) {
+          console.error(err);
+        }
       }
     }
   };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -597,25 +597,53 @@ module.exports = function(self, options) {
   };
 
   self.cleanPagesTree = async function() {
-    const req = self.apos.tasks.getReq();
+    // const req = self.apos.tasks.getReq();
 
     const locales = Object.keys(self.apos.workflow.locales)
       .filter((locale) => !locale.includes('-draft'));
 
-    const pageManager = self.apos.modules['apostrophe-any-page-manager'];
+    const pageTypes = self.apos.modules['apostrophe-pages'].options.types.map((type) => type.name);
 
-    const pages = await pageManager.find(req).toArray();
+    for (const locale of locales) {
+      const pages = await self.apos.docs.db.find({
+        workflowLocale: {$in: [locale, self.draftify(locale)]},
+        type: { $in: pageTypes }
+      }).toArray();
 
-    console.log('pages ===> ', require('util').inspect(pages, { colors: true, depth: 1 }));
+      // We group pages by workflowGuid
+      const groupedPages = pages.reduce((acc, page) => {
+        const isDraft = page.workflowLocale.includes('-draft');
 
-    // for (const locale of locales) {
-    //   const pages = await self.apos.docs.find(req, {workflowLocale: `${locale}-draft`}).toArray();
-    //   console.log('locale ===> ', locale);
+        return {
+          ...acc,
+          [page.workflowGuid]: {
+            ...acc[page.workflowGuid] && acc[page.workflowGuid],
+            ...isDraft ? { draft: page } : { live: page }
+          }
+        };
 
-    //   console.log('pages.length ===> ', pages.length);
+      }, {});
 
-    // }
+      for (const { draft, live } of Object.values(groupedPages)) {
+        // const draftTarget = draft.workflowMoved && draft.workflowMoved.target;
+        // const targetPage = pages.filter((page) => page.workflowGuid === draftTarget);
 
-    // console.log('self.apos.pages ===> ', require('util').inspect(self.apos.pages, { colors: true, depth: 0 }));
+        console.log('draft ===> ', require('util').inspect(draft, { colors: true, depth: 2 }));
+
+        console.log('live ===> ', require('util').inspect(live, { colors: true, depth: 2 }));
+
+        // await self.apos.docs.db.update({
+        //   _id: live._id
+        // }, {
+        //   $set: {
+        //     rank: draft.rank,
+        //     path: draft.path,
+        //     level: draft.level,
+        //     ...draft.workflowModified && draft.workflowModified,
+        //     ...draft.workflowMoved && draft.workflowMoved
+        //   }
+        // });
+      }
+    }
   };
 };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -605,15 +605,7 @@ module.exports = function(self, options) {
         {
           workflowLocale: {$in: [locale, self.draftify(locale)]},
           // Getting all documents with a slug starting by / to get all pages (parked ones too)
-          $and: [
-            {
-              slug: /^\//
-            },
-            {
-              // TO we want to avoid trash page here or we don't need ?
-              slug: { $ne: '/trash' }
-            }
-          ]
+          slug: /^\//
         },
         {
           _id: 1,

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -587,4 +587,35 @@ module.exports = function(self, options) {
     await resolveDeferredRelationships();
     console.log('... Done.');
   };
+
+  self.cleanPagesTreeTask = function() {
+    self.addTask('clean-pages-tree',
+      `Cleans your pages tree in the case the live one differs with the draft one,
+      The live tree will be modified based on the draft one.`,
+      self.cleanPagesTree
+    );
+  };
+
+  self.cleanPagesTree = async function() {
+    const req = self.apos.tasks.getReq();
+
+    const locales = Object.keys(self.apos.workflow.locales)
+      .filter((locale) => !locale.includes('-draft'));
+
+    const pageManager = self.apos.modules['apostrophe-any-page-manager'];
+
+    const pages = await pageManager.find(req).toArray();
+
+    console.log('pages ===> ', require('util').inspect(pages, { colors: true, depth: 1 }));
+
+    // for (const locale of locales) {
+    //   const pages = await self.apos.docs.find(req, {workflowLocale: `${locale}-draft`}).toArray();
+    //   console.log('locale ===> ', locale);
+
+    //   console.log('pages.length ===> ', pages.length);
+
+    // }
+
+    // console.log('self.apos.pages ===> ', require('util').inspect(self.apos.pages, { colors: true, depth: 0 }));
+  };
 };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -623,11 +623,6 @@ module.exports = function(self, options) {
       }, {});
 
       for (const { draft, live } of Object.values(groupedPages)) {
-
-        console.log('draft workflowMoved ===> ', require('util').inspect(draft.workflowMoved, { colors: true, depth: 2 }));
-
-        console.log('live workflowMoved ===> ', require('util').inspect(live.workflowMoved, { colors: true, depth: 2 }));
-
         try {
           await self.apos.docs.db.update({
             _id: live._id

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -588,25 +588,36 @@ module.exports = function(self, options) {
     console.log('... Done.');
   };
 
-  self.enableCleanPagesTreeTask = function() {
-    self.addTask('clean-pages-tree',
-      `Cleans your pages tree in the case the live one differs with the draft one,
-      The live tree will be modified based on the draft one.`,
-      self.cleanPagesTree
+  self.enableSyncPagesTreeTask = function() {
+    self.addTask('sync-page-tree',
+      `Synchronizes the published page tree with the draft one, across all locales.
+      If there is a discrepancy in the layout of the draft and published trees, the draft tree wins.`,
+      self.syncPagesTree
     );
   };
 
-  self.cleanPagesTree = async function() {
+  self.syncPagesTree = async function() {
     const locales = Object.keys(self.apos.workflow.locales)
       .filter((locale) => !locale.includes('-draft'));
 
     const pageTypes = self.apos.modules['apostrophe-pages'].options.types.map((type) => type.name);
 
     for (const locale of locales) {
-      const pages = await self.apos.docs.db.find({
-        workflowLocale: {$in: [locale, self.draftify(locale)]},
-        type: { $in: pageTypes }
-      }).toArray();
+      const pages = await self.apos.docs.db.find(
+        {
+          workflowLocale: {$in: [locale, self.draftify(locale)]},
+          type: { $in: pageTypes }
+        },
+        {
+          _id: 1,
+          workflowGuid: 1,
+          rank: 1,
+          path: 1,
+          level: 1,
+          workflowLocale: 1,
+          workflowMoved: 1
+        }
+      ).toArray();
 
       // We group pages by workflowGuid
       const groupedPages = pages.reduce((acc, page) => {
@@ -615,28 +626,29 @@ module.exports = function(self, options) {
         return {
           ...acc,
           [page.workflowGuid]: {
-            ...acc[page.workflowGuid] && acc[page.workflowGuid],
+            ...acc[page.workflowGuid],
             ...isDraft ? { draft: page } : { live: page }
           }
         };
-
       }, {});
 
       for (const { draft, live } of Object.values(groupedPages)) {
-        try {
-          await self.apos.docs.db.update({
-            _id: live._id
-          }, {
-            $set: {
-              rank: draft.rank,
-              path: draft.path,
-              level: draft.level,
-              ...draft.workflowModified && { workflowModified: draft.workflowModified },
-              ...draft.workflowMoved && { workflowMoved: draft.workflowMoved }
-            }
-          });
-        } catch (err) {
-          console.error(err);
+        if (draft && live) {
+          try {
+            await self.apos.docs.db.update({
+              _id: live._id
+            }, {
+              $set: {
+                rank: draft.rank,
+                path: draft.path,
+                level: draft.level,
+                ...draft.workflowModified && { workflowModified: draft.workflowModified },
+                ...draft.workflowMoved && { workflowMoved: draft.workflowMoved }
+              }
+            });
+          } catch (err) {
+            console.error(err);
+          }
         }
       }
     }


### PR DESCRIPTION
Passing a flag in the workflow configuration allows to auto commit only moves automatically.
Linked to this PR: https://github.com/apostrophecms/apostrophe/pull/3000