### PR TITLE
Fix duplicate key error in sync page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.39.1 (2021-06-07)
+* Fixes duplicate key errors in sync page tree task. For live pages not already updated with the same path.
+
 ## 2.39.0 (2021-05-20)
 * Adds `autoCommitPageMoves` flag to commit only pages moves automatically.
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -611,16 +611,17 @@ module.exports = function(self, options) {
           try {
             await updatePage(live._id, draft);
           } catch (err) {
-            if (err.code !== 11000) {
-              console.error(err);
-              return;
-            }
 
-            try {
-              await createTemporaryPaths(draft, live);
-              await updatePage(live._id, draft);
+            // This is the Mongodb error code for duplicate key error
+            if (err.code === 11000) {
+              try {
+                await createTemporaryPaths(draft, live);
+                await updatePage(live._id, draft);
 
-            } catch (err) {
+              } catch (err) {
+                console.error(err);
+              }
+            } else {
               console.error(err);
             }
           }

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -601,7 +601,42 @@ module.exports = function(self, options) {
       .filter((locale) => !locale.includes('-draft'));
 
     for (const locale of locales) {
-      const pages = await self.apos.docs.db.find(
+      const pages = await getPages(locale);
+
+      // We group pages by workflowGuid
+      const groupedPages = groupPages(pages);
+
+      for (const { draft, live } of Object.values(groupedPages)) {
+        if (draft && live) {
+          try {
+            await updatePage(live._id, draft);
+          } catch (err) {
+            if (err.code !== 11000) {
+              console.error(err);
+              return;
+            }
+
+            try {
+              await createTemporaryPaths(draft, live);
+              await updatePage(live._id, draft);
+
+            } catch (err) {
+              console.error(err);
+            }
+          }
+        }
+      }
+
+    }
+
+    try {
+      await removeTemporaryProperties();
+    } catch (err) {
+      console.error(err);
+    }
+
+    async function getPages (locale) {
+      return self.apos.docs.db.find(
         {
           workflowLocale: {$in: [locale, self.draftify(locale)]},
           // Getting all documents with a slug starting by / to get all pages (parked ones too)
@@ -617,9 +652,25 @@ module.exports = function(self, options) {
           workflowMoved: 1
         }
       ).toArray();
+    }
 
-      // We group pages by workflowGuid
-      const groupedPages = pages.reduce((acc, page) => {
+    function updatePage (liveId, draft) {
+      return self.apos.docs.db.updateOne({
+        _id: liveId
+      }, {
+        $set: {
+          rank: draft.rank,
+          level: draft.level,
+          path: draft.path,
+          ...draft.workflowModified && { workflowModified: draft.workflowModified },
+          ...draft.workflowMoved && { workflowMoved: draft.workflowMoved },
+          workflowMigrationDone: true
+        }
+      });
+    }
+
+    function groupPages (pages) {
+      return pages.reduce((acc, page) => {
         const isDraft = page.workflowLocale.includes('-draft');
 
         return {
@@ -630,26 +681,39 @@ module.exports = function(self, options) {
           }
         };
       }, {});
+    }
 
-      for (const { draft, live } of Object.values(groupedPages)) {
-        if (draft && live) {
-          try {
-            await self.apos.docs.db.update({
-              _id: live._id
-            }, {
-              $set: {
-                rank: draft.rank,
-                path: draft.path,
-                level: draft.level,
-                ...draft.workflowModified && { workflowModified: draft.workflowModified },
-                ...draft.workflowMoved && { workflowMoved: draft.workflowMoved }
-              }
-            });
-          } catch (err) {
-            console.error(err);
-          }
+    async function createTemporaryPaths (draft, live) {
+      const duplicates = await self.apos.docs.db.find({
+        workflowLocale: live.workflowLocale,
+        path: draft.path
+      }).toArray();
+
+      console.log('duplicates ===> ', require('util').inspect(duplicates, { colors: true, depth: 2 }));
+
+      for (const page of duplicates) {
+        // If the migration has already been done, we cannot set temporary path
+        // and you are migrating duplicate paths from draft to live
+        if (!page.workflowMigrationDone) {
+          await self.apos.docs.db.update({
+            _id: page._id
+          }, {
+            $set: {
+              path: `temporary-${self.apos.utils.generateId()}`
+            }
+          });
         }
       }
+    }
+
+    async function removeTemporaryProperties () {
+      return self.apos.docs.db.updateMany({
+        slug: /^\//
+      }, {
+        $unset: {
+          workflowMigrationDone: 1
+        }
+      });
     }
   };
 };

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -689,8 +689,6 @@ module.exports = function(self, options) {
         path: draft.path
       }).toArray();
 
-      console.log('duplicates ===> ', require('util').inspect(duplicates, { colors: true, depth: 2 }));
-
       for (const page of duplicates) {
         // If the migration has already been done, we cannot set temporary path
         // and you are migrating duplicate paths from draft to live


### PR DESCRIPTION
## Purpose
Avoiding duplicate key errors from mongoDB during migration.
If duplicate path error, we mark the pages with the duplicate path if they have not been updated already (because their path will be updated with the draft version later).