### PR TITLE
Fix assembly bug when creating site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.39.3 (2021-06-24)
-* Fix assembly crashing when creating new site.
+* Fix assembly crashing when creating new site or hanging on startup. A regression introduced in version 2.39.2.
 
 ## 2.39.2 (2021-06-21)
 * Get autoCommitPageMoves option from workflow module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.39.3 (2021-06-24)
+* Fix assembly crashing when creating new site.
+
 ## 2.39.2 (2021-06-21)
 * Get autoCommitPageMoves option from workflow module.
 

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -31,19 +31,10 @@ module.exports = {
   },
 
   construct: function(self, options) {
-    const superModulesReady = self.modulesReady;
-    self.modulesReady = function(callback) {
-      return superModulesReady(function(err) {
-        if (err) {
-          callback(err);
-        }
-
-        self.autoCommitPageMoves = self.apos.modules['apostrophe-workflow']
-          .options.autoCommitPageMoves || false;
-
-        return callback(null);
-      });
-    };
+    self.on('apostrophe:modulesReady', function() {
+      self.autoCommitPageMoves = self.apos.modules['apostrophe-workflow']
+        .options.autoCommitPageMoves || false;
+    });
 
     var superGetPathIndexParams = self.getPathIndexParams;
     self.getPathIndexParams = function() {

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -32,11 +32,17 @@ module.exports = {
 
   construct: function(self, options) {
     const superModulesReady = self.modulesReady;
-    self.modulesReady = function() {
-      superModulesReady();
+    self.modulesReady = function(callback) {
+      return superModulesReady(function(err) {
+        if (err) {
+          callback(err);
+        }
 
-      self.autoCommitPageMoves = self.apos.modules['apostrophe-workflow']
-        .options.autoCommitPageMoves || false;
+        self.autoCommitPageMoves = self.apos.modules['apostrophe-workflow']
+          .options.autoCommitPageMoves || false;
+
+        return callback(null);
+      });
     };
 
     var superGetPathIndexParams = self.getPathIndexParams;

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -31,7 +31,7 @@ module.exports = {
   },
 
   construct: function(self, options) {
-    self.on('apostrophe:modulesReady', function() {
+    self.on('apostrophe:modulesReady', 'setAutoCommitPageMoves', function() {
       self.autoCommitPageMoves = self.apos.modules['apostrophe-workflow']
         .options.autoCommitPageMoves || false;
     });


### PR DESCRIPTION
## Purpose
Issue when creating a website on an Assembly project using the `apostrophe-headless` module. 
The `modulesReady` callback was missing so the website creation was loading infinitely