### PR TITLE
dcad-1078: When fetching the live version of a document for comparison, do so using the appropriate manager module, so that all cursor filters for that type are consulted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* When fetching the live version of a document for comparison, do so using the appropriate manager module, so that all cursor filters for that type are consulted. Thanks to Michelin for their support of this work.
+
 ## 2.39.3 (2021-06-28)
 
 * Fix assembly crashing when creating new site or hanging on startup in the presence of headless. A regression introduced in version 2.39.2.

--- a/lib/modules/apostrophe-workflow-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-workflow-schemas/public/js/user.js
@@ -14,7 +14,7 @@ apos.define('apostrophe-schemas', {
         return next();
       }
       return apos.modules['apostrophe-workflow'].api('get-live',
-        _.assign(_.pick(object, 'workflowGuid', 'workflowLocale'), { resolveRelationshipsToDraft: true }),
+        _.assign(_.pick(object, 'workflowGuid', 'workflowLocale', 'type'), { resolveRelationshipsToDraft: true }),
         function(data) {
           if (data.status !== 'ok') {
             return fail();

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -363,6 +363,7 @@ module.exports = function(self, options) {
       }
       var guid = self.apos.launder.string(req.body.workflowGuid);
       var locale = self.apos.launder.string(req.body.workflowLocale);
+      const type = self.apos.launder.string(req.body.type);
       locale = self.liveify(locale);
       var live;
 
@@ -380,10 +381,19 @@ module.exports = function(self, options) {
       });
 
       function get(callback) {
-        return self.apos.docs.find(req, { workflowGuid: guid, workflowLocale: locale }).trash(null).published(null).workflowLocale(locale).toObject(function(err, _live) {
-          live = _live;
-          return callback(err);
-        });
+        const manager = self.apos.docs.getManager(type);
+        if (manager) {
+          return manager.find(req, { workflowGuid: guid, workflowLocale: locale }).trash(null).published(null).workflowLocale(locale).toObject(function(err, _live) {
+            live = _live;
+            return callback(err);
+          });
+        } else {
+          // For bc
+          return self.apos.docs.find(req, { workflowGuid: guid, workflowLocale: locale }).trash(null).published(null).workflowLocale(locale).toObject(function(err, _live) {
+            live = _live;
+            return callback(err);
+          });
+        }
       }
 
       function ids(callback) {


### PR DESCRIPTION
This allows any impacts from default values of cursor filters to be taken into account, as requested by enterprise client. There is no bc break as we still do it with plain `docs.find` if a `type` is not sent to the API.