### PR TITLE
1111 fix export progress

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -128,6 +128,7 @@ module.exports = function(self, options) {
       function run(req, reporting, callback) {
         var results = {};
         var ids = self.apos.launder.ids(req.body.ids);
+        var countRelated = self.apos.launder.integer(req.body.countRelated);
         var tasks = [];
         ids = _.uniq(ids);
         return async.series({
@@ -149,9 +150,11 @@ module.exports = function(self, options) {
             var relatedTypes = Array.isArray(req.body.relatedTypes) ? req.body.relatedTypes : [];
             var relatedExisting = !!req.body.relatedExisting;
             var relatedIds = [];
-            reporting.setTotal(ids.length);
             var unfetched = ids;
+
+            reporting.setTotal(ids.length + countRelated);
             return fetchBatch();
+
             function fetchBatch() {
               var batch = unfetched.slice(0, batchSize);
               if (!batch.length) {
@@ -172,22 +175,26 @@ module.exports = function(self, options) {
                 return callback(null);
               }
               unfetched = unfetched.slice(batchSize);
-              return self.findDocs(req, { _id: { $in: batch } }).areas(true).joins(true).toArray(function(err, docs) {
-                if (err) {
-                  return callback(err);
-                }
-                return self.getRelated(docs, function(err, related) {
+              return self
+                .findDocs(req, { _id: { $in: batch } })
+                .areas(true)
+                .joins(true)
+                .toArray(function(err, docs) {
                   if (err) {
                     return callback(err);
                   }
-                  related = _.filter(related, function(doc) {
-                    return _.contains(relatedTypes, doc.type);
+                  return self.getRelated(docs, function(err, related) {
+                    if (err) {
+                      return callback(err);
+                    }
+                    related = _.filter(related, function(doc) {
+                      return _.contains(relatedTypes, doc.type);
+                    });
+                    relatedIds = relatedIds.concat(_.pluck(related, '_id'));
+
+                    return fetchBatch();
                   });
-                  relatedIds = relatedIds.concat(_.pluck(related, '_id'));
-                  reporting.setTotal(_.uniq(relatedIds.concat(ids)).length);
-                  return fetchBatch();
                 });
-              });
             }
           },
           sortIds: function(callback) {
@@ -228,7 +235,6 @@ module.exports = function(self, options) {
             });
           },
           forceExport: function(callback) {
-            reporting.setTotal(ids.length);
             return async.eachSeries(tasks, function(task, callback) {
               return self.forceExport(req, task._id, req.body.locales, { existing: task.existing }, function(err, result) {
                 if (err) {

--- a/public/js/batch-force-export-modal.js
+++ b/public/js/batch-force-export-modal.js
@@ -63,12 +63,14 @@ apos.define('apostrophe-workflow-batch-force-export-modal', {
       self.options.body.locales = locales;
       self.options.body.related = related;
       self.options.body.relatedTypes = [];
+      self.options.body.countRelated = 0;
       self.$el.find('[name="relatedTypes"]:checked').each(function() {
         self.options.body.relatedTypes.push($(this).attr('value'));
+        self.options.body.countRelated += $(this).parent().data('count') || 0;
       });
       self.options.body.relatedExisting = self.$el.find('[name="relatedExisting"]').prop('checked');
+
       return callback(null);
     };
-
   }
 });

--- a/views/relatedByType.html
+++ b/views/relatedByType.html
@@ -4,7 +4,10 @@
   <h4>{{ __ns('apostrophe', 'Only related documents of the types you choose below will be exported.') }}</h4>
   {% for type in data.types %}
     <ul>
-      <li><input type="checkbox" name="relatedTypes" value="{{ type }}" /> {{ __ns('apostrophe', data.labels[type]) }} ({{ data.counts[type] }})</li>
+      <li data-count={{ data.counts[type] }}>
+        <input type="checkbox" name="relatedTypes" value="{{ type }}" />
+        {{ __ns('apostrophe', data.labels[type]) }} ({{ data.counts[type] }})
+      </li>
     </ul>
   {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary

[1111](https://gitlab-dcadcx.michelin.net/pa/apostrophe-enhancements/-/issues/1111)

Fixes the bad percentage when batch exporting pieces in another locale with related documents. Related documents not being taken into account in the computation.

## What are the specific steps to test this change?

*For example:*
> 1. `npm link` apostrophe-workflow in an A2 project.
> 2. Run your project and log as admin.
> 3. Select any amount of pieces and batch export them with related documents (images, files...)
> 4. Make sure the progress bar goes to 100% and not above.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
