### PR TITLE
fix blog + workflow combo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.40.1 (2022-10-25)
+
+* Fixed a bug when workflow is combined with the blog module and a blog post is dated in the future. This caused problems when editing the blog post again.
+
 ## 2.40.0 (2022-05-03)
 
 `forceExportExistingRelatedDocuments`: by default, when force exporting, a choice is also offered to force export related documents even if they already exist in the target locale, overwriting the document in the target locale. If this option is explicitly set to `false`, this choice is not offered.

--- a/lib/modules/apostrophe-workflow-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-workflow-schemas/public/js/user.js
@@ -122,7 +122,7 @@ apos.define('apostrophe-schemas', {
           return fail();
         });
       function fail() {
-        self.apos.utils.error('Nonfatal error: cannot fetch live version of draft doc.');
+        apos.utils.error('Nonfatal error: cannot fetch live version of draft doc.');
         return next();
       }
       function next() {
@@ -191,7 +191,7 @@ apos.define('apostrophe-schemas', {
         matches = slug && slug.match(/^\/([^/]+)/);
         if (!matches) {
           // No first component or no slug at all
-          slug = prefix + (slug || '/' + self.apos.utils.slugify(title));
+          slug = prefix + (slug || '/' + apos.utils.slugify(title));
         } else {
           var existing = matches[1];
           if (('/' + existing) === workflow.options.prefixes[liveLocale]) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -408,7 +408,8 @@ module.exports = function(self, options) {
           } else {
             finder = manager;
           }
-          return finder.find(req, { workflowGuid: guid, workflowLocale: locale }).trash(null).published(null).workflowLocale(locale).toObject(function(err, _live) {
+          const find = finder.findForEditing || finder.find;
+          return find(req, { workflowGuid: guid, workflowLocale: locale }).trash(null).published(null).workflowLocale(locale).toObject(function(err, _live) {
             live = _live;
             return callback(err);
           });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.40.0",
+  "version": "2.40.1",
   "scripts": {
     "test": "eslint . && mocha"
   },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Formerly, if a draft blog post was saved with a publication date in the future, it was impossible to open it for editing again.

I also fixed a bug that interfered with the proper logging of the error involved.

This is critical for a client.

## What are the specific steps to test this change?

Create an "article" in `apostrophe-enterprise-testbed`. Put the publication date in the future. Save the draft, then try to reopen the modal. It will fail unless apostrophe-workflow is this branch.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
