### PR TITLE
Remove deep-get-set-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fixed vulnerability by removing `deep-get-set` package.
+
 ## 2.40.1 (2022-10-25)
 
 * Fixed a bug when workflow is combined with the blog module and a blog post is dated in the future. This caused problems when editing the blog post again.

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,5 @@
 var _ = require('@sailshq/lodash');
 var async = require('async');
-var deep = require('deep-get-set');
 var qs = require('qs');
 var removeDotPathViaSplice = require('./removeDotPathViaSplice.js');
 var Promise = require('bluebird');
@@ -1503,7 +1502,7 @@ module.exports = function(self, { autoCommitPageMoves }) {
     }
 
     function getObject(context, objects, dotPath) {
-      return deep(context, dotPath);
+      return _.get(context, dotPath);
     }
 
     function deleteObject(context, objects, value) {
@@ -1524,7 +1523,7 @@ module.exports = function(self, { autoCommitPageMoves }) {
       }
       var stem = self.getStem(afterDotPath);
       var index = self.getIndex(afterDotPath);
-      var array = deep(context, stem);
+      var array = _.get(context, stem);
       if (!Array.isArray(array)) {
         // Contexts are too different, receiving context has
         // no array at this level, gracefully ignore
@@ -1544,7 +1543,7 @@ module.exports = function(self, { autoCommitPageMoves }) {
       }
       var stem = self.getStem(beforeDotPath);
       var index = self.getIndex(beforeDotPath);
-      var array = deep(context, stem);
+      var array = _.get(context, stem);
       if (!Array.isArray(array)) {
         // Contexts are too different, receiving context has
         // no array at this level, gracefully ignore
@@ -1557,7 +1556,7 @@ module.exports = function(self, { autoCommitPageMoves }) {
     }
 
     function appendObject(context, objects, path, object) {
-      var array = deep(context, path);
+      var array = _.get(context, path);
       if (!Array.isArray(array)) {
         return false;
       }
@@ -1580,11 +1579,11 @@ module.exports = function(self, { autoCommitPageMoves }) {
       if (dotPath) {
         try {
           var patch = diff.diff(oldObject, newObject);
-          var targetObject = deep(context, dotPath);
+          var targetObject = _.get(context, dotPath);
           diff.patch(targetObject, patch);
         } catch (e) {
           self.apos.utils.error(e);
-          deep(context, dotPath, originalNewObject);
+          _.set(context, dotPath, originalNewObject);
         }
       }
     }
@@ -2320,8 +2319,8 @@ module.exports = function(self, { autoCommitPageMoves }) {
           }
 
           var parentDotPath = getParentDotPath(widgetInfo.dotPath);
-          if (deep(draft, parentDotPath)) {
-            deep(draft, widgetInfo.dotPath, widgetInfo.object);
+          if (_.get(draft, parentDotPath)) {
+            _.set(draft, widgetInfo.dotPath, widgetInfo.object);
             success.push(self.liveify(locale));
           } else if (addMissingArea()) {
             // Great
@@ -2339,8 +2338,8 @@ module.exports = function(self, { autoCommitPageMoves }) {
             // if we're either at the root, or a valid parent path
             var areaParentDotPath = getParentDotPath(areaDotPath);
             try {
-              if ((!areaParentDotPath.length) || (deep(areaParentDotPath))) {
-                deep(draft, areaDotPath, { type: 'area', items: [ widgetInfo.object ] });
+              if ((!areaParentDotPath.length) || (_.get(areaParentDotPath))) {
+                _.set(draft, areaDotPath, { type: 'area', items: [ widgetInfo.object ] });
                 return true;
               }
             } catch (e) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@sailshq/lodash": "^3.10.3",
     "async": "^1.5.2",
     "bluebird": "^3.7.2",
-    "deep-get-set": "^1.1.1",
     "eslint-config-apostrophe": "^2.0.2",
     "express-session": "^1.17.1",
     "json-diff": "^0.5.3",


### PR DESCRIPTION
## Summary

All versions of package deep-get-set are vulnerable to Prototype Pollution via the 'deep' function. Note: This vulnerability derives from an incomplete fix of [CVE-2020-7715](https://security.snyk.io/vuln/SNYK-JS-DEEPGETSET-598666)

## What are the specific steps to test this change?

> 1. Run the website and log in as an admin
> 2. Edit an area and check if it saved correctly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

