### PR TITLE
fix error handling for isModified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+* Fix lack of error handling in the promise-based implementation of `setWorkflowModified`. With this change, bugs in overrides of
+`isModified` etc. should be easier to find.
+
 ## 2.40.3 (2023-03-06)
 
 * Removes `apostrophe` as a peer dependency.

--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -454,7 +454,7 @@ module.exports = function(self, options) {
   // be nice if promise events had a way to say "after all the
   // others," but they don't so far.
 
-  self.on('apostrophe-docs:afterSave', 'setWorkflowModified', function(req, doc, options) {
+  self.on('apostrophe-docs:afterSave', 'setWorkflowModified', async (req, doc, options) => {
     if (!self.includeType(doc.type)) {
       return;
     }
@@ -463,24 +463,23 @@ module.exports = function(self, options) {
       return;
     }
     const isModified = Promise.promisify(self.isModified);
-    return isModified(req, doc).then(function(modified) {
-      // If there is no modification and that's not news, no update.
-      // Otherwise always update so we get the last editor's name
-      if ((modified === doc.workflowModified) && (!modified)) {
-        return;
-      }
-      const $set = {
-        workflowModified: modified
-      };
-      if (req.user && req.user._id && req.user.title) {
-        $set.workflowLastEditor = req.user.title;
-        $set.workflowLastEditorId = req.user._id;
-      }
-      return self.apos.docs.db.update({
-        _id: doc._id
-      }, {
-        $set: $set
-      });
+    const modified = await isModified(req, doc);
+    // If there is no modification and that's not news, no update.
+    // Otherwise always update so we get the last editor's name
+    if ((modified === doc.workflowModified) && (!modified)) {
+      return;
+    }
+    const $set = {
+      workflowModified: modified
+    };
+    if (req.user && req.user._id && req.user.title) {
+      $set.workflowLastEditor = req.user.title;
+      $set.workflowLastEditorId = req.user._id;
+    }
+    return self.apos.docs.db.update({
+      _id: doc._id
+    }, {
+      $set: $set
     });
   });
 


### PR DESCRIPTION
This may help with future bugs like this one, although I can't fix the callback-based nature of the lower-level methods, so there may still be cases where errors are not well-caught and nothing much can be done. At least we're not dropping errors that do reach the level of this handler now.